### PR TITLE
fix: replace nodemon with ts-node-dev, add tsconfig-paths to handle path aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/server.ts",
   "scripts": {
     "start": "node dist/server.ts",
-    "dev": "nodemon src/server.ts",
+    "dev": "ts-node-dev -r tsconfig-paths/register --respawn src/server.ts",
     "build": "tsc"
   },
   "author": "",
@@ -28,6 +28,7 @@
     "@types/jsonwebtoken": "^9.0.9",
     "@types/node": "^20.11.24",
     "ts-node-dev": "^2.0.0",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.3.3"
   }
 }


### PR DESCRIPTION
## Title
fix: replace nodemon with ts-node-dev, add tsconfig-paths to handle path aliases

## Purpose  
Nodemon wasn’t working with this TypeScript setup, and path aliases like `@/config/auth` weren’t resolving.  
Switched to `ts-node-dev` and added `tsconfig-paths` to fix it.

## Changes  
- Replaced `nodemon` with `ts-node-dev`
- Updated `dev` script in `package.json`:
  ```json
  "dev": "ts-node-dev -r tsconfig-paths/register --respawn src/server.ts"
- Installed `tsconfig-paths` for resolving TS path aliases