### PR TITLE
chore: remove unused frontendURL, and rename FRONTEND_URL to CLIENT_URL

### DIFF
--- a/src/config/auth.ts
+++ b/src/config/auth.ts
@@ -13,6 +13,5 @@ export const authConfig = {
   jwt: {
     secret: process.env.JWT_SECRET!,
     expiresIn: '1d' as SignOptions['expiresIn'],
-  },
-  frontendURL: process.env.FRONTEND_URL!,
+  }
 }; 

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -9,8 +9,8 @@ const router = express.Router();
 
 // start GitHub OAuth login
 router.get('/github', (req, res) => {
-  const githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${authConfig.github.clientId}&redirect_uri=${authConfig.github.callbackURL}&scope=${authConfig.github.scope}`;
-  res.redirect(githubAuthUrl);
+    const githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${authConfig.github.clientId}&redirect_uri=${authConfig.github.callbackURL}&scope=${authConfig.github.scope}`;
+    res.redirect(githubAuthUrl);
 });
 
 // GitHub OAuth callback
@@ -78,10 +78,10 @@ router.get('/callback/github', async (req, res) => {
     });
     
     // redirect to frontend
-    res.redirect(`${process.env.FRONTEND_URL}/auth/callback`);
+    res.redirect(`${process.env.CLIENT_URL}/auth/callback`);
   } catch (error) {
     console.error('GitHub OAuth error:', error);
-    res.redirect(`${process.env.FRONTEND_URL}/auth/error`);
+    res.redirect(`${process.env.CLIENT_URL}/auth/error`);
   }
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ app.use(cors({ origin: process.env.CLIENT_URL, credentials: true }));
 app.use(express.json());
 app.use(cookieParser());
 
-// Routes (upcoming)
+// Routes
 app.use('/api/auth', authRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/activities', activityRoutes);


### PR DESCRIPTION
## Title
chore: remove unused `frontendURL` + rename `FRONTEND_URL` to `CLIENT_URL`

## Purpose
- While checking a login-related bug, I found that `frontendURL` wasn’t being used at all.
- Renamed the environment variable (`FRONTEND_URL` → `CLIENT_URL`) to avoid confusion.

## Changes
- Removed `frontendURL` from `authConfig` (not used)
- Renamed `FRONTEND_URL` to `CLIENT_URL`, and updated related references

## Optional
- Tried to run the server on port 5000, but **macOS’s ControlCenter** had other plans.
So I gave up and changed it to 5001 in `.env`🥺...