### PR TITLE
feat: improve auth structure, seed logic, and add user profile API

### DIFF
--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -7,7 +7,6 @@ declare global {
     interface Request {
       user?: {
         id: string;
-        githubId: string;
         username: string;
         image?: string;
       };
@@ -33,7 +32,6 @@ export const authToken = (req: Request, res: Response, next: NextFunction) => {
   try {
     const decoded = jwt.verify(token, authConfig.jwt.secret) as {
       id: string;
-      githubId: string;
       username: string;
       image?: string;
     };

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -54,10 +54,9 @@ router.get('/callback/github', async (req, res) => {
       create: userData,
     });
 
-    // create JWT token - exclude accessToken for security
+    // create JWT token - exclude accessToken and githubId for security
     const payload = { 
       id: user.id,
-      githubId: user.githubId,
       username: user.username,
       image: user.image
     };
@@ -95,8 +94,6 @@ router.get('/session', authToken, async (req, res) => {
     const user = await prisma.user.findUnique({
       where: { id: req.user.id },
       select: {
-        id: true,
-        githubId: true,
         username: true,
         image: true,
       },

--- a/src/routes/plantRoutes.ts
+++ b/src/routes/plantRoutes.ts
@@ -1,16 +1,7 @@
 import prisma from '@/config/db';
 import { authToken } from '@/middlewares/authMiddleware';
-import express, { Request, Response } from 'express';
-
-// Extend the Request interface to include user from authenticateToken middleware
-interface AuthRequest extends Request {
-  user?: {
-    id: string;
-    githubId: string;
-    username: string;
-    image?: string;
-  };
-}
+import { AuthRequest } from '@/types/auth';
+import express, { Response } from 'express';
 
 const router = express.Router();
 

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,4 +1,6 @@
+import prisma from '@/config/db';
 import { createUser, deleteUser, getUser, updateUser } from '@/controllers/authController';
+import { AuthRequest } from '@/types/auth';
 import express from 'express';
 import { authToken } from '../middlewares/authMiddleware';
 
@@ -6,6 +8,72 @@ const router = express.Router();
 
 // Apply authentication middleware to all routes
 router.use(authToken);
+
+// Get user profile with all related information
+router.get('/profile', async (req: AuthRequest, res) => {
+  try {
+    const userId = req.user!.id;
+
+    // Get all user information in parallel
+    const [userInfo, seedCount, userBadges, equippedItems, plants] = await Promise.all([
+      // Basic user info
+      prisma.user.findUnique({
+        where: { id: userId },
+        select: {
+          username: true,
+          image: true,
+        },
+      }),
+      // Total seed count
+      prisma.seed.count({
+        where: { userId }
+      }),
+      // User's badges
+      prisma.userBadge.findMany({
+        where: { userId },
+        include: { badge: true },
+        orderBy: { awardedAt: 'desc' }
+      }),
+      // User's equipped items (background and pot)
+      prisma.userItem.findMany({
+        where: { 
+          userId,
+          equipped: true
+        },
+        include: { 
+          item: true 
+        }
+      }),
+      // User's plants
+      prisma.plant.findMany({
+        where: { userId },
+        orderBy: { createdAt: 'desc' }
+      })
+    ]);
+
+    if (!userInfo) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+
+    // Separate equipped items by category
+    const equippedBackground = equippedItems.find(item => item.item.category === 'BACKGROUND');
+    const equippedPot = equippedItems.find(item => item.item.category === 'POT');
+
+    res.json({
+      user: userInfo,
+      seedCount,  // Return seed counts
+      badges: userBadges,
+      equipped: {
+        background: equippedBackground?.item || null,
+        pot: equippedPot?.item || null
+      },
+      plants
+    });
+  } catch (error) {
+    console.error('Error fetching user profile:', error);
+    res.status(500).json({ message: 'Error fetching user profile' });
+  }
+});
 
 // User routes
 router.post('/', createUser);

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,10 +1,8 @@
 import { Request } from 'express';
 
-// Extend the Request interface to include user from authenticateToken middleware
 export interface AuthRequest extends Request {
   user?: {
     id: string;
-    githubId: string;
     username: string;
     image?: string;
   };


### PR DESCRIPTION
## Title  
feat: improve auth structure, seed logic, and add user profile API

## Purpose  
- Remove sensitive or unnecessary fields (`githubId`) from authentication payload to enhance security  
- Simplify and improve maintainability of auth and seed-related logic  
- Add a comprehensive user profile API to support front-end needs  

## Changes  
### 🔐 Authentication
- Removed `githubId` from JWT token and user info payload  
- Refactored `AuthRequest` interface into a separate `types` file  
- Cleaned up duplicated interface definitions  

### 🌱 Seed
- Simplified seed creation logic  
- Added functionality to update existing seeds  
- Removed unused seed-to-plant conversion code  

### 👤 User Profile
- Implemented new API endpoint to fetch full user profile  
  → includes seeds, badges, equipped items, and plant information  

## Optional  
- These updates prepare the backend for better modularity and safer token usage  
- The new user profile API will allow more efficient rendering on MyPage or Dashboard components  