### PR TITLE
feat: add isAdmin to session API response

### DIFF
--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -91,14 +91,23 @@ router.get('/session', authToken, async (req, res) => {
       return res.status(401).json({ message: 'User not authenticated' });
     }
 
-    const user = await prisma.user.findUnique({
-      where: { id: req.user.id },
-      select: {
-        username: true,
-        image: true,
-      },
+    const [user, superUser] = await Promise.all([
+      prisma.user.findUnique({
+        where: { id: req.user.id },
+        select: {
+          username: true,
+          image: true,
+        },
+      }),
+      prisma.superUser.findUnique({
+        where: { userId: req.user.id },
+      }),
+    ]);
+
+    res.json({
+      user,
+      isAdmin: !!superUser
     });
-    res.json(user);
   } catch (error) {
     res.status(500).json({ message: 'Error fetching session' });
   }


### PR DESCRIPTION
## Title  
feat: add isAdmin to session API response

## Purpose  
- We needed a way to tell if a user is an admin from the frontend,  
so this update adds an `isAdmin` flag to the session response for easier role-based access in the back-office.

## Changes  
- **Session API Update**
  - Checked for `superUser` record in the session logic  
  - Added `isAdmin: true/false` in the API response  
  - Makes it simpler to guard admin-only pages on the frontend