### PR TITLE
feat: add image upload with Cloudinary and metadata storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,16 @@
   "license": "MIT",
   "dependencies": {
     "@prisma/client": "^6.8.2",
+    "@types/multer": "^1.4.12",
     "axios": "^1.9.0",
+    "cloudinary": "^2.6.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "express-rate-limit": "^7.5.0",
     "jsonwebtoken": "^9.0.2",
+    "multer": "^2.0.1",
     "prisma": "^6.8.2"
   },
   "devDependencies": {

--- a/prisma/migrations/20250605055314_add_uploaded_images/migration.sql
+++ b/prisma/migrations/20250605055314_add_uploaded_images/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "UploadedImage" (
+    "id" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UploadedImage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "UploadedImage_type_idx" ON "UploadedImage"("type");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -173,3 +173,14 @@ enum AdminRole {
   CONTENT
   SHOP_MANAGER
 }
+
+model UploadedImage {
+  id        String   @id @default(cuid())
+  type      String   // CROP, BADGE, BACKGROUND, POT
+  name      String   // 이미지 이름
+  url       String   // Cloudinary URL
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([type])
+}

--- a/src/config/cloudinary.ts
+++ b/src/config/cloudinary.ts
@@ -1,0 +1,9 @@
+import { v2 as cloudinary } from 'cloudinary';
+
+cloudinary.config({
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET,
+});
+
+export default cloudinary; 

--- a/src/routes/uploadRoutes.ts
+++ b/src/routes/uploadRoutes.ts
@@ -1,0 +1,140 @@
+import { PrismaClient } from '@prisma/client';
+import express from 'express';
+import multer from 'multer';
+import cloudinary from '../config/cloudinary';
+
+const router = express.Router();
+const prisma = new PrismaClient();
+
+// Cloudinary 응답 타입 정의
+interface CloudinaryUploadResult {
+  secure_url: string;
+  [key: string]: any;
+}
+
+// Multer 설정
+const storage = multer.memoryStorage();
+const upload = multer({ storage: storage });
+
+// 공통 업로드 함수
+const uploadToCloudinary = async (file: Express.Multer.File, preset: string, folder: string, filename?: string): Promise<CloudinaryUploadResult> => {
+  return new Promise((resolve, reject) => {
+    cloudinary.uploader.upload_stream(
+      {
+        upload_preset: preset,
+        folder: folder,
+        public_id: filename
+      },
+      (error, result) => {
+        if (error) reject(error);
+        else resolve(result as CloudinaryUploadResult);
+      }
+    ).end(file.buffer);
+  });
+};
+
+// 작물 이미지 업로드
+router.post('/crops', upload.single('image'), async (req, res) => {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ message: '이미지 파일이 필요합니다.' });
+    }
+
+    const filename = req.body.filename || req.file.originalname;
+    const result = await uploadToCloudinary(req.file, 'git-plants(crops)', 'images/crops', filename);
+    
+    // DB에 이미지 정보 저장
+    const uploadedImage = await prisma.uploadedImage.create({
+      data: {
+        type: 'CROP',
+        name: filename,
+        url: result.secure_url
+      }
+    });
+
+    res.json({ success: true, data: { ...result, dbRecord: uploadedImage } });
+  } catch (error) {
+    console.error('작물 이미지 업로드 에러:', error);
+    res.status(500).json({ success: false, message: '이미지 업로드에 실패했습니다.' });
+  }
+});
+
+// 배경화면 이미지 업로드
+router.post('/backgrounds', upload.single('image'), async (req, res) => {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ message: '이미지 파일이 필요합니다.' });
+    }
+
+    const filename = req.body.filename || req.file.originalname;
+    const result = await uploadToCloudinary(req.file, 'git-plants(backgrounds)', 'items/backgrounds', filename);
+    
+    // DB에 이미지 정보 저장
+    const uploadedImage = await prisma.uploadedImage.create({
+      data: {
+        type: 'BACKGROUND',
+        name: filename,
+        url: result.secure_url
+      }
+    });
+
+    res.json({ success: true, data: { ...result, dbRecord: uploadedImage } });
+  } catch (error) {
+    console.error('배경화면 이미지 업로드 에러:', error);
+    res.status(500).json({ success: false, message: '이미지 업로드에 실패했습니다.' });
+  }
+});
+
+// 화분 이미지 업로드
+router.post('/pots', upload.single('image'), async (req, res) => {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ message: '이미지 파일이 필요합니다.' });
+    }
+
+    const filename = req.body.filename || req.file.originalname;
+    const result = await uploadToCloudinary(req.file, 'git-plants(pots)', 'items/pots', filename);
+    
+    // DB에 이미지 정보 저장
+    const uploadedImage = await prisma.uploadedImage.create({
+      data: {
+        type: 'POT',
+        name: filename,
+        url: result.secure_url
+      }
+    });
+
+    res.json({ success: true, data: { ...result, dbRecord: uploadedImage } });
+  } catch (error) {
+    console.error('화분 이미지 업로드 에러:', error);
+    res.status(500).json({ success: false, message: '이미지 업로드에 실패했습니다.' });
+  }
+});
+
+// 뱃지 이미지 업로드
+router.post('/badges', upload.single('image'), async (req, res) => {
+  try {
+    if (!req.file) {
+      return res.status(400).json({ message: '이미지 파일이 필요합니다.' });
+    }
+
+    const filename = req.body.filename || req.file.originalname;
+    const result = await uploadToCloudinary(req.file, 'git-plants(badges)', 'images/badges', filename);
+    
+    // DB에 이미지 정보 저장
+    const uploadedImage = await prisma.uploadedImage.create({
+      data: {
+        type: 'BADGE',
+        name: filename,
+        url: result.secure_url
+      }
+    });
+
+    res.json({ success: true, data: { ...result, dbRecord: uploadedImage } });
+  } catch (error) {
+    console.error('뱃지 이미지 업로드 에러:', error);
+    res.status(500).json({ success: false, message: '이미지 업로드에 실패했습니다.' });
+  }
+});
+
+export default router; 

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import authRoutes from './routes/authRoutes';
 import gardenRoutes from './routes/gardenRoutes';
 import plantRoutes from './routes/plantRoutes';
 import seedRoutes from './routes/seedRoutes';
+import uploadRoutes from './routes/uploadRoutes';
 import userRoutes from './routes/userRoutes';
 
 dotenv.config();
@@ -26,6 +27,7 @@ app.use('/api/plants', plantRoutes);
 app.use('/api/seeds', seedRoutes);
 app.use('/api/garden', gardenRoutes);
 app.use('/api/admin', adminRoutes);
+app.use('/api/upload', uploadRoutes);
 
 const PORT = process.env.PORT || 5000;
 app.listen(PORT, () => {


### PR DESCRIPTION
## Title
feat: add image upload with Cloudinary and metadata storage

## Purpose
- Set up a basic image upload flow for the dashboard using Cloudinary.
- Save image metadata (`type`, `name`, `url`) to the database for later use.

## Changes
- **Cloudinary Integration**
  - Installed `cloudinary`, `multer`, and related type definitions
  - Added Cloudinary configuration for file uploads

- **Migration (Prisma)**
  - Added `UploadedImage` model with `type`, `name`, and `url` fields
  - Generated migration file to apply schema changes

- **API**  
  - Created upload routes:
    - `/upload/crop`
    - `/upload/background`
    - `/upload/pot`
    - `/upload/badge`
  - Connected Cloudinary uploads with API and DB logic