### PR TITLE
refactor: simplify Prisma models and update related routes

### DIFF
--- a/prisma/migrations/20250605085025_simplify_models_and_relations/migration.sql
+++ b/prisma/migrations/20250605085025_simplify_models_and_relations/migration.sql
@@ -1,0 +1,71 @@
+/*
+  Warnings:
+
+  - The primary key for the `Badge` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `Badge` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `GardenItem` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `GardenItem` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `MonthlyPlant` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `id` column on the `MonthlyPlant` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `Seed` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `id` on the `Seed` table. All the data in the column will be lost.
+  - You are about to drop the column `obtainedAt` on the `Seed` table. All the data in the column will be lost.
+  - You are about to drop the column `type` on the `Seed` table. All the data in the column will be lost.
+  - Changed the type of `badgeId` on the `UserBadge` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `itemId` on the `UserItem` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- DropForeignKey
+ALTER TABLE "UserBadge" DROP CONSTRAINT "UserBadge_badgeId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "UserItem" DROP CONSTRAINT "UserItem_itemId_fkey";
+
+-- DropIndex
+DROP INDEX "Seed_userId_idx";
+
+-- AlterTable
+ALTER TABLE "Badge" DROP CONSTRAINT "Badge_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" SERIAL NOT NULL,
+ADD CONSTRAINT "Badge_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "GardenItem" DROP CONSTRAINT "GardenItem_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" SERIAL NOT NULL,
+ADD CONSTRAINT "GardenItem_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "MonthlyPlant" DROP CONSTRAINT "MonthlyPlant_pkey",
+DROP COLUMN "id",
+ADD COLUMN     "id" SERIAL NOT NULL,
+ADD CONSTRAINT "MonthlyPlant_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "Seed" DROP CONSTRAINT "Seed_pkey",
+DROP COLUMN "id",
+DROP COLUMN "obtainedAt",
+DROP COLUMN "type",
+ADD COLUMN     "count" INTEGER NOT NULL DEFAULT 0,
+ADD CONSTRAINT "Seed_pkey" PRIMARY KEY ("userId");
+
+-- AlterTable
+ALTER TABLE "UserBadge" DROP COLUMN "badgeId",
+ADD COLUMN     "badgeId" INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE "UserItem" DROP COLUMN "itemId",
+ADD COLUMN     "itemId" INTEGER NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "UserBadge_badgeId_idx" ON "UserBadge"("badgeId");
+
+-- CreateIndex
+CREATE INDEX "UserItem_itemId_idx" ON "UserItem"("itemId");
+
+-- AddForeignKey
+ALTER TABLE "UserItem" ADD CONSTRAINT "UserItem_itemId_fkey" FOREIGN KEY ("itemId") REFERENCES "GardenItem"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserBadge" ADD CONSTRAINT "UserBadge_badgeId_fkey" FOREIGN KEY ("badgeId") REFERENCES "Badge"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,20 +8,20 @@ datasource db {
 }
 
 model User {
-  id              String           @id @default(cuid())
-  githubId        String           @unique
-  username        String
-  accessToken     String
-  image           String?
-  sessions        Session[]
+  id               String           @id @default(cuid())
+  githubId         String           @unique
+  username         String
+  accessToken      String
+  image            String?
+  createdAt        DateTime         @default(now())
+  updatedAt        DateTime         @updatedAt
   githubActivities GitHubActivity[]
-  plants          Plant[]
-  seeds           Seed[]
-  userItems       UserItem[]
-  userBadges      UserBadge[]
-  createdAt       DateTime         @default(now())
-  updatedAt       DateTime         @updatedAt
-  superUser       SuperUser?       // 관리자일 경우 연결
+  plants           Plant[]
+  seeds            Seed?
+  sessions         Session[]
+  superUser        SuperUser?
+  userBadges       UserBadge[]
+  userItems        UserItem[]
 }
 
 model Session {
@@ -35,10 +35,10 @@ model Session {
 model GitHubActivity {
   id                String   @id @default(cuid())
   userId            String
-  type              String   // Contribution, Commit, PullRequest
+  type              String
   repository        String
   title             String
-  description       String?  @db.Text
+  description       String?
   url               String
   eventId           String   @unique
   contributionCount Int?
@@ -49,31 +49,23 @@ model GitHubActivity {
 }
 
 model Plant {
-  id           String     @id @default(cuid())
-  userId       String
-  name         String
-  stage        GrowthStage @default(SEED)
-  currentContributions Int @default(0)
-  createdAt    DateTime   @default(now())
-  updatedAt    DateTime   @updatedAt
-  user         User       @relation(fields: [userId], references: [id], onDelete: Cascade)
-  growthLogs   GrowthLog[]
+  id                   String      @id @default(cuid())
+  userId               String
+  name                 String
+  stage                GrowthStage @default(SEED)
+  currentContributions Int         @default(0)
+  createdAt            DateTime    @default(now())
+  updatedAt            DateTime    @updatedAt
+  growthLogs           GrowthLog[]
+  user                 User        @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
-}
-
-enum GrowthStage {
-  SEED        // 0~9
-  SPROUT      // 10~29
-  GROWING     // 30~49
-  MATURE      // 50~69
-  HARVEST     // 70~100
 }
 
 model GrowthLog {
   id        String   @id @default(cuid())
   plantId   String
-  log       String   @db.Text
+  log       String
   count     Int
   createdAt DateTime @default(now())
   plant     Plant    @relation(fields: [plantId], references: [id], onDelete: Cascade)
@@ -82,105 +74,107 @@ model GrowthLog {
 }
 
 model Seed {
-  id        String   @id @default(cuid())
-  userId    String
-  type      String
-  obtainedAt DateTime @default(now())
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-
-  @@index([userId])
+  userId String @id
+  count  Int    @default(0)
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model GardenItem {
-  id         String   @id @default(cuid())
-  name       String
-  category   String   // BACKGROUND, POT, etc
-  imageUrl   String
-  price      Int
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
+  name        String
+  category    String
+  imageUrl    String
+  price       Int
+  createdAt   DateTime   @default(now())
+  updatedAt   DateTime   @updatedAt
   updatedById String?
+  id          Int        @id @default(autoincrement())
   updatedBy   SuperUser? @relation("GardenItemUpdatedBy", fields: [updatedById], references: [id])
-  userItems  UserItem[]
+  userItems   UserItem[]
 }
 
 model UserItem {
-  id            String     @id @default(cuid())
-  userId        String
-  itemId        String
-  equipped      Boolean    @default(false)
-  acquiredAt    DateTime   @default(now())
-  user          User       @relation(fields: [userId], references: [id], onDelete: Cascade)
-  item          GardenItem @relation(fields: [itemId], references: [id], onDelete: Cascade)
+  id         String     @id @default(cuid())
+  userId     String
+  equipped   Boolean    @default(false)
+  acquiredAt DateTime   @default(now())
+  itemId     Int
+  item       GardenItem @relation(fields: [itemId], references: [id], onDelete: Cascade)
+  user       User       @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
   @@index([itemId])
 }
 
 model Badge {
-  id         String   @id @default(cuid())
-  name       String
-  condition  String   // 자동 지급 조건 설명
-  imageUrl   String
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
+  name        String
+  condition   String
+  imageUrl    String
+  createdAt   DateTime    @default(now())
+  updatedAt   DateTime    @updatedAt
   updatedById String?
-  updatedBy   SuperUser? @relation("BadgeUpdatedBy", fields: [updatedById], references: [id])
-  userBadges UserBadge[]
+  id          Int         @id @default(autoincrement())
+  updatedBy   SuperUser?  @relation("BadgeUpdatedBy", fields: [updatedById], references: [id])
+  userBadges  UserBadge[]
 }
 
 model UserBadge {
   id        String   @id @default(cuid())
   userId    String
-  badgeId   String
   awardedAt DateTime @default(now())
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  badgeId   Int
   badge     Badge    @relation(fields: [badgeId], references: [id], onDelete: Cascade)
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
   @@index([badgeId])
 }
 
 model MonthlyPlant {
-  id            String   @id @default(cuid())
-  title         String
-  description   String   @db.Text
-  imageUrl      String
-  month         Int
-  year          Int
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
-  updatedById   String?
-  updatedBy     SuperUser? @relation("MonthlyPlantUpdatedBy", fields: [updatedById], references: [id])
+  title       String
+  description String
+  imageUrl    String
+  month       Int
+  year        Int
+  createdAt   DateTime   @default(now())
+  updatedAt   DateTime   @updatedAt
+  updatedById String?
+  id          Int        @id @default(autoincrement())
+  updatedBy   SuperUser? @relation("MonthlyPlantUpdatedBy", fields: [updatedById], references: [id])
 }
 
 model SuperUser {
-  id           String     @id @default(cuid())
-  userId       String     @unique
-  role         AdminRole  @default(ADMIN)
-  user         User       @relation(fields: [userId], references: [id], onDelete: Cascade)
-  createdAt    DateTime   @default(now())
-  updatedAt    DateTime   @updatedAt
+  id         String         @id @default(cuid())
+  userId     String         @unique
+  role       AdminRole      @default(ADMIN)
+  createdAt  DateTime       @default(now())
+  updatedAt  DateTime       @updatedAt
+  badgeEdits Badge[]        @relation("BadgeUpdatedBy")
+  itemEdits  GardenItem[]   @relation("GardenItemUpdatedBy")
+  plantEdits MonthlyPlant[] @relation("MonthlyPlantUpdatedBy")
+  user       User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
 
-  // 관리 리소스 추적용
-  plantEdits   MonthlyPlant[] @relation("MonthlyPlantUpdatedBy")
-  itemEdits    GardenItem[]   @relation("GardenItemUpdatedBy")
-  badgeEdits   Badge[]        @relation("BadgeUpdatedBy")
+model UploadedImage {
+  id        String   @id @default(cuid())
+  type      String
+  name      String
+  url       String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([type])
+}
+
+enum GrowthStage {
+  SEED
+  SPROUT
+  GROWING
+  MATURE
+  HARVEST
 }
 
 enum AdminRole {
   ADMIN
   CONTENT
   SHOP_MANAGER
-}
-
-model UploadedImage {
-  id        String   @id @default(cuid())
-  type      String   // CROP, BADGE, BACKGROUND, POT
-  name      String   // 이미지 이름
-  url       String   // Cloudinary URL
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@index([type])
 }

--- a/src/routes/adminRoutes.ts
+++ b/src/routes/adminRoutes.ts
@@ -144,7 +144,7 @@ router.put('/monthly-plants/:id', requireRole(['ADMIN', 'CONTENT']), async (req:
     const { title, description, imageUrl } = req.body;
     
     const updatedPlant = await prisma.monthlyPlant.update({
-      where: { id: req.params.id },
+      where: { id: parseInt(req.params.id) },
       data: {
         title,
         description,
@@ -201,7 +201,7 @@ router.put('/items/:id', requireRole(['ADMIN', 'SHOP_MANAGER']), async (req: Aut
     const { name, category, imageUrl, price } = req.body;
     
     const updatedItem = await prisma.gardenItem.update({
-      where: { id: req.params.id },
+      where: { id: parseInt(req.params.id) },
       data: {
         name,
         category,
@@ -256,7 +256,7 @@ router.put('/badges/:id', requireRole(['ADMIN', 'CONTENT']), async (req: AuthReq
     const { name, condition, imageUrl } = req.body;
     
     const updatedBadge = await prisma.badge.update({
-      where: { id: req.params.id },
+      where: { id: parseInt(req.params.id) },
       data: {
         name,
         condition,

--- a/src/routes/gardenRoutes.ts
+++ b/src/routes/gardenRoutes.ts
@@ -26,7 +26,7 @@ router.get('/items', async (req: AuthRequest, res: Response) => {
 router.get('/items/:id', async (req: AuthRequest, res: Response) => {
   try {
     const item = await prisma.gardenItem.findUnique({
-      where: { id: req.params.id }
+      where: { id: parseInt(req.params.id) }
     });
     
     if (!item) {
@@ -62,7 +62,7 @@ router.post('/user-items', async (req: AuthRequest, res: Response) => {
     
     // Check if item exists
     const item = await prisma.gardenItem.findUnique({
-      where: { id: itemId }
+      where: { id: parseInt(itemId) }
     });
     
     if (!item) {
@@ -73,7 +73,7 @@ router.post('/user-items', async (req: AuthRequest, res: Response) => {
     const existingItem = await prisma.userItem.findFirst({
       where: {
         userId: req.user!.id,
-        itemId
+        itemId: parseInt(itemId)
       }
     });
     
@@ -85,7 +85,7 @@ router.post('/user-items', async (req: AuthRequest, res: Response) => {
     const userItem = await prisma.userItem.create({
       data: {
         userId: req.user!.id,
-        itemId,
+        itemId: parseInt(itemId),
         equipped: false
       }
     });

--- a/src/routes/uploadRoutes.ts
+++ b/src/routes/uploadRoutes.ts
@@ -6,17 +6,17 @@ import cloudinary from '../config/cloudinary';
 const router = express.Router();
 const prisma = new PrismaClient();
 
-// Cloudinary 응답 타입 정의
+// set type for cloudinary upload result
 interface CloudinaryUploadResult {
   secure_url: string;
   [key: string]: any;
 }
 
-// Multer 설정
+// set multer storage
 const storage = multer.memoryStorage();
 const upload = multer({ storage: storage });
 
-// 공통 업로드 함수
+// common upload function
 const uploadToCloudinary = async (file: Express.Multer.File, preset: string, folder: string, filename?: string): Promise<CloudinaryUploadResult> => {
   return new Promise((resolve, reject) => {
     cloudinary.uploader.upload_stream(
@@ -33,7 +33,7 @@ const uploadToCloudinary = async (file: Express.Multer.File, preset: string, fol
   });
 };
 
-// 작물 이미지 업로드
+// upload crop image
 router.post('/crops', upload.single('image'), async (req, res) => {
   try {
     if (!req.file) {
@@ -43,7 +43,7 @@ router.post('/crops', upload.single('image'), async (req, res) => {
     const filename = req.body.filename || req.file.originalname;
     const result = await uploadToCloudinary(req.file, 'git-plants(crops)', 'images/crops', filename);
     
-    // DB에 이미지 정보 저장
+    // save image info to DB
     const uploadedImage = await prisma.uploadedImage.create({
       data: {
         type: 'CROP',
@@ -59,7 +59,7 @@ router.post('/crops', upload.single('image'), async (req, res) => {
   }
 });
 
-// 배경화면 이미지 업로드
+// upload background image
 router.post('/backgrounds', upload.single('image'), async (req, res) => {
   try {
     if (!req.file) {
@@ -69,7 +69,7 @@ router.post('/backgrounds', upload.single('image'), async (req, res) => {
     const filename = req.body.filename || req.file.originalname;
     const result = await uploadToCloudinary(req.file, 'git-plants(backgrounds)', 'items/backgrounds', filename);
     
-    // DB에 이미지 정보 저장
+    // save image info to DB
     const uploadedImage = await prisma.uploadedImage.create({
       data: {
         type: 'BACKGROUND',
@@ -85,7 +85,7 @@ router.post('/backgrounds', upload.single('image'), async (req, res) => {
   }
 });
 
-// 화분 이미지 업로드
+// upload pot image
 router.post('/pots', upload.single('image'), async (req, res) => {
   try {
     if (!req.file) {
@@ -95,7 +95,7 @@ router.post('/pots', upload.single('image'), async (req, res) => {
     const filename = req.body.filename || req.file.originalname;
     const result = await uploadToCloudinary(req.file, 'git-plants(pots)', 'items/pots', filename);
     
-    // DB에 이미지 정보 저장
+    // save image info to DB
     const uploadedImage = await prisma.uploadedImage.create({
       data: {
         type: 'POT',
@@ -111,7 +111,7 @@ router.post('/pots', upload.single('image'), async (req, res) => {
   }
 });
 
-// 뱃지 이미지 업로드
+// upload badge image
 router.post('/badges', upload.single('image'), async (req, res) => {
   try {
     if (!req.file) {
@@ -121,7 +121,7 @@ router.post('/badges', upload.single('image'), async (req, res) => {
     const filename = req.body.filename || req.file.originalname;
     const result = await uploadToCloudinary(req.file, 'git-plants(badges)', 'images/badges', filename);
     
-    // DB에 이미지 정보 저장
+    // save image info to DB
     const uploadedImage = await prisma.uploadedImage.create({
       data: {
         type: 'BADGE',

--- a/src/services/githubService.ts
+++ b/src/services/githubService.ts
@@ -62,7 +62,7 @@ export const fetchUserActivities = async (userId: string, username: string): Pro
   try {
     console.log('Fetching activities for user:', username);
 
-    // 사용자의 accessToken을 데이터베이스에서 가져옴
+    // get user's accessToken from DB
     const user = await prisma.user.findUnique({
       where: { id: userId },
       select: { accessToken: true }


### PR DESCRIPTION
## Title
refactor: simplify Prisma models and update related routes

## Purpose
- Simplify schema by unifying ID generation and optimizing model relationships.
- Reflect changes across relevant API routes to maintain consistency.

## Changes  
### 🧱 Prisma Schema  
- **Seed Model**
  - Removed `id`; set `userId` as primary key
  - Removed `type`, `obtainedAt`; added `count` (default: 0)
  - Removed index on `userId`

- **ID Type Changes**
  - Changed `id` fields from `String (cuid)` to `Int (autoincrement)` for:
    - `GardenItem`, `Badge`, `MonthlyPlant`
  - Updated related foreign keys accordingly:
    - `UserItem.itemId`, `UserBadge.badgeId` from `String → Int`

### 🔁 API Routes  
- Updated API logic and route handlers to align with schema changes (e.g., `id` types, `Seed` model behavior)