### PR TITLE
refactor: remove role-based access control and secure upload routes with isAdmin

### DIFF
--- a/prisma/migrations/20250605121216_remove_admin_role/migration.sql
+++ b/prisma/migrations/20250605121216_remove_admin_role/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `role` on the `SuperUser` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "SuperUser" DROP COLUMN "role";
+
+-- DropEnum
+DROP TYPE "AdminRole";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -145,7 +145,6 @@ model MonthlyPlant {
 model SuperUser {
   id         String         @id @default(cuid())
   userId     String         @unique
-  role       AdminRole      @default(ADMIN)
   createdAt  DateTime       @default(now())
   updatedAt  DateTime       @updatedAt
   badgeEdits Badge[]        @relation("BadgeUpdatedBy")
@@ -171,10 +170,4 @@ enum GrowthStage {
   GROWING
   MATURE
   HARVEST
-}
-
-enum AdminRole {
-  ADMIN
-  CONTENT
-  SHOP_MANAGER
 }

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -1,4 +1,6 @@
 import { authConfig } from '@/config/auth';
+import prisma from '@/config/db';
+import { AuthRequest } from '@/types/auth';
 import { NextFunction, Request, Response } from 'express';
 import jwt from 'jsonwebtoken';
 
@@ -41,3 +43,21 @@ export const authToken = (req: Request, res: Response, next: NextFunction) => {
     return res.status(403).json({ message: 'Invalid token' });
   }
 }; 
+
+export const isAdmin = async (req: AuthRequest, res: Response, next: NextFunction) => {
+  if (!req.user) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+
+  const superUser = await prisma.superUser.findUnique({
+    where: { userId: req.user.id }
+  });
+
+  if (!superUser) {
+    return res.status(403).json({ message: 'Forbidden: Admin access required' });
+  }
+
+  // Add superUser to request for role-based access control
+  req.superUser = superUser;
+  next();
+};

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -9,7 +9,6 @@ export interface AuthRequest extends Request {
   superUser?: {
     id: string;
     userId: string;
-    role: 'ADMIN' | 'CONTENT' | 'SHOP_MANAGER';
     createdAt: Date;
     updatedAt: Date;
   };


### PR DESCRIPTION
## Title  
refactor: remove role-based access control and secure upload routes with isAdmin

## Purpose  
- Simplify the auth system by removing unused `AdminRole` logic.
- Upgrade security stronger by restricting upload routes to superusers only via `isAdmin` middleware.

## Changes  
- **Auth Logic Simplification**
  - Removed `AdminRole` enum and `role` field in `AuthRequest` interface  
  - Replaced role-based middleware (`requireRole`) with a single `isAdmin` check

- **API Security Update**
  - Applied `isAdmin` middleware to all image upload routes  
  - Restricted `/upload` endpoints to verified superusers only  
  - Updated request types for consistency