### PR TITLE
refactor: clean up Session model and improve refresh token handling

### DIFF
--- a/prisma/migrations/20250617050043_remove_session_and_improve_refresh_token/migration.sql
+++ b/prisma/migrations/20250617050043_remove_session_and_improve_refresh_token/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Session` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Session" DROP CONSTRAINT "Session_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "RefreshToken" ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- DropTable
+DROP TABLE "Session";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,19 +18,10 @@ model User {
   githubActivities GitHubActivity[]
   plants           Plant[]
   seeds            Seed?
-  sessions         Session[]
   refreshTokens    RefreshToken[]
   superUser        SuperUser?
   userBadges       UserBadge[]
   userItems        UserItem[]
-}
-
-model Session {
-  id           String   @id @default(cuid())
-  sessionToken String   @unique
-  userId       String
-  expires      DateTime
-  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model GitHubActivity {
@@ -173,6 +164,7 @@ model RefreshToken {
   expiresAt DateTime
   isRevoked Boolean  @default(false)
   isAdmin   Boolean  @default(false)
+  createdAt DateTime @default(now())
 
   @@index([userId])
 }


### PR DESCRIPTION
## Title  
refactor: clean up Session model and improve refresh token handling

## Purpose  
- Remove unused `Session` table and fix issue where `isRevoked` was always `false`.

## Changes  
- Removed `Session` model and its relation from the `User` model  
- Updated `RefreshToken` schema with `createdAt` and proper token management  
- Added cleanup logic for expired or revoked refresh tokens  
- Renamed `revokeAllSessions` → `revokeAllRefreshTokens` for clarity  
- Regenerated migration to reflect schema changes