### PR TITLE
feat: extend item model and upload APIs to support icon images

### DIFF
--- a/prisma/migrations/20250617070925_add_icon_url/migration.sql
+++ b/prisma/migrations/20250617070925_add_icon_url/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `iconUrl` to the `GardenItem` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "GardenItem" ADD COLUMN     "iconUrl" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,6 +75,7 @@ model GardenItem {
   name        String
   category    String
   imageUrl    String
+  iconUrl String
   price       Int
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt


### PR DESCRIPTION
## Title
feat: extend item model and upload APIs to support icon images

## Purpose  
- To support icon image uploads when registering items by adding an `iconUrl` field and updating related APIs.

## Changes  
- **Database**
  - Added `iconUrl` field to `GardenItem` model
  - Created a new Prisma migration for the schema change

- **Item Creation API**
  - Added validation for the `iconUrl` field
  - Added `superUser` authorization check for security

- **Image Upload**
  - Enabled icon image uploads for background and pot items
  - Added a dedicated endpoint for uploading garden item icons
  - Improved error messages and standardized API responses