### PR TITLE
feat: add mode support for background items and simplify image storage

### DIFF
--- a/prisma/migrations/20250618035030_add_mode_to_garden_items/migration.sql
+++ b/prisma/migrations/20250618035030_add_mode_to_garden_items/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "GardenItem" ADD COLUMN     "mode" TEXT;

--- a/prisma/migrations/20250618062043_add_plant_image_url_and_remove_uploaded_image/migration.sql
+++ b/prisma/migrations/20250618062043_add_plant_image_url_and_remove_uploaded_image/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - You are about to drop the `UploadedImage` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `imageUrl` to the `Plant` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Plant" ADD COLUMN     "imageUrl" TEXT NOT NULL;
+
+-- DropTable
+DROP TABLE "UploadedImage";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -74,8 +74,9 @@ model Seed {
 model GardenItem {
   name        String
   category    String
+  mode        String?
   imageUrl    String
-  iconUrl String
+  iconUrl     String
   price       Int
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,7 @@ model Plant {
   id                   String      @id @default(cuid())
   userId               String
   name                 String
+  imageUrl             String
   stage                GrowthStage @default(SEED)
   currentContributions Int         @default(0)
   createdAt            DateTime    @default(now())
@@ -145,17 +146,6 @@ model SuperUser {
   itemEdits  GardenItem[]   @relation("GardenItemUpdatedBy")
   plantEdits MonthlyPlant[] @relation("MonthlyPlantUpdatedBy")
   user       User           @relation(fields: [userId], references: [id], onDelete: Cascade)
-}
-
-model UploadedImage {
-  id        String   @id @default(cuid())
-  type      String
-  name      String
-  url       String
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-
-  @@index([type])
 }
 
 model RefreshToken {

--- a/src/routes/plantRoutes.ts
+++ b/src/routes/plantRoutes.ts
@@ -56,6 +56,9 @@ router.post('/', async (req: AuthRequest, res: Response) => {
       data: {
         name,
         userId: req.user!.id,
+        imageUrl: '',
+        stage: 'SEED',
+        currentContributions: 0
       }
     });
     

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -55,7 +55,10 @@ router.get('/profile', clientAuth, async (req: AuthRequest, res) => {
     }
 
     // Separate equipped items by category
-    const equippedBackground = equippedItems.find(item => item.item.category === 'BACKGROUND');
+    const equippedBackground = equippedItems.find(item => 
+      item.item.category === 'BACKGROUND' &&
+      (item.item.mode === 'GARDEN' || item.item.mode === 'MINI')  // 배경화면은 GARDEN 또는 MINI 모드
+    );
     const equippedPot = equippedItems.find(item => item.item.category === 'POT');
 
     res.json({


### PR DESCRIPTION
## Title  
feat: add mode support for background items and simplify image storage

## Purpose  
- To support client-side rendering of background items by mode (e.g., GARDEN, MINI),  
and to simplify image storage by removing the `UploadedImage` model and using direct `imageUrl` fields.

## Changes  
- **GardenItem / Background**
  - Added `mode` field to `GardenItem` model via Prisma migration
  - Implemented `mode` validation for background items on create/update
  - Filtered background items by `mode` in profile endpoint

- **Image Storage**
  - Removed `UploadedImage` model from Prisma schema
  - Added `imageUrl` field to `Plant` model
  - Applied changes to routes: store image URLs directly in `Plant` and `Badge`