### PR TITLE
feat: restructure plant system with monthly logic, GitHub-based growth, and admin upload support

### DIFF
--- a/prisma/migrations/20250702023722_enhance_monthly_plant_system/migration.sql
+++ b/prisma/migrations/20250702023722_enhance_monthly_plant_system/migration.sql
@@ -1,0 +1,66 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `plantId` on the `GrowthLog` table. All the data in the column will be lost.
+  - You are about to drop the column `imageUrl` on the `MonthlyPlant` table. All the data in the column will be lost.
+  - You are about to drop the `Plant` table. If the table is not empty, all the data it contains will be lost.
+  - A unique constraint covering the columns `[month,year]` on the table `MonthlyPlant` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `userPlantId` to the `GrowthLog` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `name` to the `MonthlyPlant` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "GrowthLog" DROP CONSTRAINT "GrowthLog_plantId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Plant" DROP CONSTRAINT "Plant_userId_fkey";
+
+-- DropIndex
+DROP INDEX "GrowthLog_plantId_idx";
+
+-- AlterTable
+ALTER TABLE "GrowthLog" DROP COLUMN "plantId",
+ADD COLUMN     "userPlantId" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "MonthlyPlant" DROP COLUMN "imageUrl",
+ADD COLUMN     "iconUrl" TEXT,
+ADD COLUMN     "imageUrls" TEXT[],
+ADD COLUMN     "name" TEXT NOT NULL;
+
+-- DropTable
+DROP TABLE "Plant";
+
+-- CreateTable
+CREATE TABLE "UserPlant" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "monthlyPlantId" INTEGER NOT NULL,
+    "stage" "GrowthStage" NOT NULL DEFAULT 'SEED',
+    "currentContributions" INTEGER NOT NULL DEFAULT 0,
+    "plantedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserPlant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "UserPlant_userId_idx" ON "UserPlant"("userId");
+
+-- CreateIndex
+CREATE INDEX "UserPlant_monthlyPlantId_idx" ON "UserPlant"("monthlyPlantId");
+
+-- CreateIndex
+CREATE INDEX "GrowthLog_userPlantId_idx" ON "GrowthLog"("userPlantId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MonthlyPlant_month_year_key" ON "MonthlyPlant"("month", "year");
+
+-- AddForeignKey
+ALTER TABLE "UserPlant" ADD CONSTRAINT "UserPlant_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserPlant" ADD CONSTRAINT "UserPlant_monthlyPlantId_fkey" FOREIGN KEY ("monthlyPlantId") REFERENCES "MonthlyPlant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GrowthLog" ADD CONSTRAINT "GrowthLog_userPlantId_fkey" FOREIGN KEY ("userPlantId") REFERENCES "UserPlant"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250702110124_add_harvest_count/migration.sql
+++ b/prisma/migrations/20250702110124_add_harvest_count/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "UserPlant" ADD COLUMN     "harvestCount" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/migrations/20250702123409_remove_growth_log_model/migration.sql
+++ b/prisma/migrations/20250702123409_remove_growth_log_model/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `currentContributions` on the `UserPlant` table. All the data in the column will be lost.
+  - You are about to drop the `GrowthLog` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "GrowthLog" DROP CONSTRAINT "GrowthLog_userPlantId_fkey";
+
+-- AlterTable
+ALTER TABLE "UserPlant" DROP COLUMN "currentContributions";
+
+-- DropTable
+DROP TABLE "GrowthLog";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,29 +41,20 @@ model GitHubActivity {
 }
 
 model UserPlant {
-  id                   String        @id @default(cuid())
-  userId               String
-  monthlyPlantId       Int           // MonthlyPlant 참조
-  stage                GrowthStage   @default(SEED)
-  currentContributions Int           @default(0) // 마이그레이션에서 추가된 필드
-  plantedAt            DateTime      @default(now())
-  updatedAt            DateTime      @updatedAt
-  user                 User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  monthlyPlant         MonthlyPlant  @relation(fields: [monthlyPlantId], references: [id], onDelete: Cascade)
-  growthLogs           GrowthLog[]
+  id             String        @id @default(cuid())
+  userId         String
+  monthlyPlantId Int           // MonthlyPlant 참조
+  stage          GrowthStage   @default(SEED)
+  harvestCount   Int           @default(0) // 수확 횟수 추가
+  plantedAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
+  user           User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  monthlyPlant   MonthlyPlant  @relation(fields: [monthlyPlantId], references: [id], onDelete: Cascade)
 
   @@index([userId])
   @@index([monthlyPlantId])
 }
 
-model GrowthLog {
-  id          String   @id @default(cuid())
-  userPlantId String
-  createdAt   DateTime @default(now())
-  userPlant   UserPlant @relation(fields: [userPlantId], references: [id], onDelete: Cascade)
-
-  @@index([userPlantId])
-}
 
 model Seed {
   userId String @id

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,7 @@ model User {
   createdAt        DateTime         @default(now())
   updatedAt        DateTime         @updatedAt
   githubActivities GitHubActivity[]
-  plants           Plant[]
+  userPlants       UserPlant[]
   seeds            Seed?
   refreshTokens    RefreshToken[]
   superUser        SuperUser?
@@ -40,30 +40,29 @@ model GitHubActivity {
   @@index([userId])
 }
 
-model Plant {
-  id                   String      @id @default(cuid())
+model UserPlant {
+  id                   String        @id @default(cuid())
   userId               String
-  name                 String
-  imageUrls            String[]
-  stage                GrowthStage @default(SEED)
-  currentContributions Int         @default(0)
-  createdAt            DateTime    @default(now())
-  updatedAt            DateTime    @updatedAt
+  monthlyPlantId       Int           // MonthlyPlant 참조
+  stage                GrowthStage   @default(SEED)
+  currentContributions Int           @default(0) // 마이그레이션에서 추가된 필드
+  plantedAt            DateTime      @default(now())
+  updatedAt            DateTime      @updatedAt
+  user                 User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  monthlyPlant         MonthlyPlant  @relation(fields: [monthlyPlantId], references: [id], onDelete: Cascade)
   growthLogs           GrowthLog[]
-  user                 User        @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
+  @@index([monthlyPlantId])
 }
 
 model GrowthLog {
-  id        String   @id @default(cuid())
-  plantId   String
-  log       String
-  count     Int
-  createdAt DateTime @default(now())
-  plant     Plant    @relation(fields: [plantId], references: [id], onDelete: Cascade)
+  id          String   @id @default(cuid())
+  userPlantId String
+  createdAt   DateTime @default(now())
+  userPlant   UserPlant @relation(fields: [userPlantId], references: [id], onDelete: Cascade)
 
-  @@index([plantId])
+  @@index([userPlantId])
 }
 
 model Seed {
@@ -126,8 +125,10 @@ model UserBadge {
 
 model MonthlyPlant {
   title       String
+  name        String
   description String
-  imageUrl    String
+  imageUrls   String[]
+  iconUrl     String?
   month       Int
   year        Int
   createdAt   DateTime   @default(now())
@@ -135,6 +136,9 @@ model MonthlyPlant {
   updatedById String?
   id          Int        @id @default(autoincrement())
   updatedBy   SuperUser? @relation("MonthlyPlantUpdatedBy", fields: [updatedById], references: [id])
+  userPlants  UserPlant[]
+
+  @@unique([month, year])
 }
 
 model SuperUser {

--- a/src/controllers/auth/userController.ts
+++ b/src/controllers/auth/userController.ts
@@ -40,9 +40,10 @@ export const getUserProfile = async (req: AuthRequest, res: Response) => {
         }
       }),
       // User's plants
-      prisma.plant.findMany({
+      prisma.userPlant.findMany({
         where: { userId },
-        orderBy: { createdAt: 'desc' }
+        include: { monthlyPlant: true },
+        orderBy: { plantedAt: 'desc' }
       })
     ]);
 

--- a/src/controllers/item/gardenController.ts
+++ b/src/controllers/item/gardenController.ts
@@ -38,14 +38,43 @@ export const getGardenItemById = async (req: AuthRequest, res: Response) => {
 // Get user's items
 export const getUserItems = async (req: AuthRequest, res: Response) => {
   try {
+    const { category } = req.query;
+    
     const userItems = await prisma.userItem.findMany({
-      where: { userId: req.user!.id },
+      where: {
+        userId: req.user!.id,
+        ...(category && {
+          item: {
+            category: category as string
+          }
+        })
+      },
       include: { item: true },
       orderBy: { acquiredAt: 'desc' }
     });
     res.json(userItems);
   } catch (error) {
     res.status(500).json({ message: 'Error fetching user items' });
+  }
+};
+
+// Get user's crops specifically
+export const getUserCrops = async (req: AuthRequest, res: Response) => {
+  try {
+    const userCrops = await prisma.userItem.findMany({
+      where: { 
+        userId: req.user!.id,
+        item: {
+          category: 'crops'
+        }
+      },
+      include: { item: true },
+      orderBy: { acquiredAt: 'desc' }
+    });
+    
+    res.json(userCrops);
+  } catch (error) {
+    res.status(500).json({ message: 'Error fetching user crops' });
   }
 };
 

--- a/src/controllers/item/plantController.ts
+++ b/src/controllers/item/plantController.ts
@@ -2,87 +2,189 @@ import prisma from '@/config/db';
 import { AuthRequest } from '@/types/auth';
 import { Response } from 'express';
 
-// Get all user's plants
+// Calculate plant contributions based on GitHub activities since planting
+async function calculatePlantContributions(userPlantId: string, userId: string, plantedAt: Date): Promise<number> {
+  const contributions = await prisma.gitHubActivity.aggregate({
+    where: {
+      userId,
+      type: 'contribution',
+      createdAt: { gte: plantedAt }
+    },
+    _sum: { contributionCount: true }
+  });
+  
+  return contributions._sum.contributionCount || 0;
+}
+
+// Handle plant harvest - create crop item and reset plant
+async function handleHarvest(userPlant: any, userId: string) {
+  const monthlyPlant = userPlant.monthlyPlant;
+  
+  // Check if crop item already exists for this monthly plant
+  let cropItem = await prisma.gardenItem.findFirst({
+    where: {
+      name: `${monthlyPlant.name}`,
+      category: 'crops'
+    }
+  });
+  
+  // If crop item doesn't exist, create it
+  if (!cropItem) {
+    cropItem = await prisma.gardenItem.create({
+      data: {
+        name: `${monthlyPlant.name}`,
+        category: 'crops',
+        imageUrl: monthlyPlant.imageUrls[4], // Use HARVEST stage image
+        iconUrl: monthlyPlant.iconUrl || monthlyPlant.imageUrls[4],
+        price: 0, // Free since it's earned through harvest
+        updatedById: null
+      }
+    });
+  }
+  
+  // Add crop to user's items
+  const userCrop = await prisma.userItem.create({
+    data: {
+      userId,
+      itemId: cropItem.id,
+      equipped: false
+    },
+    include: {
+      item: true
+    }
+  });
+  
+  // Harvest achieved - reset to SEED stage and increment harvest count
+  const updatedPlant = await prisma.userPlant.update({
+    where: { id: userPlant.id },
+    data: { 
+      stage: 'SEED', // Reset to SEED stage
+      harvestCount: userPlant.harvestCount + 1 // Increment harvest count
+    }
+  });
+  
+  return {
+    ...updatedPlant,
+    harvested: true,
+    newHarvestCount: updatedPlant.harvestCount,
+    resetToSeed: true,
+    cropReceived: userCrop,
+    message: `Congratulations! Your ${monthlyPlant.name} has been harvested and you received a crop!`
+  };
+}
+
+// Get all user's plants with GitHub-based contributions
 export const getPlants = async (req: AuthRequest, res: Response) => {
   try {
-    const plants = await prisma.plant.findMany({
+    const userPlants = await prisma.userPlant.findMany({
       where: { userId: req.user!.id },
-      include: { growthLogs: true },
-      orderBy: { createdAt: 'desc' }
+      include: { 
+        monthlyPlant: true
+      },
+      orderBy: { plantedAt: 'desc' }
     });
     
-    // Add current stage image URL to each plant
-    const plantsWithCurrentImage = plants.map(plant => ({
-      ...plant,
-      currentImageUrl: getCurrentStageImageUrl(plant.imageUrls, plant.stage)
-    }));
+    // Calculate current contributions for each plant based on GitHub activities
+    const plantsWithContributions = await Promise.all(
+      userPlants.map(async (userPlant) => {
+        const currentContributions = await calculatePlantContributions(userPlant.id, req.user!.id, userPlant.plantedAt);
+        
+        return {
+          ...userPlant,
+          currentContributions,
+          currentImageUrl: getCurrentStageImageUrl(userPlant.monthlyPlant.imageUrls, userPlant.stage)
+        };
+      })
+    );
     
-    res.json(plantsWithCurrentImage);
+    res.json(plantsWithContributions);
   } catch (error) {
     res.status(500).json({ message: 'Error fetching plants' });
   }
 };
 
-// Get plant by ID
+// Get plant by ID with GitHub-based contributions
 export const getPlantById = async (req: AuthRequest, res: Response) => {
   try {
-    const plant = await prisma.plant.findUnique({
+    const userPlant = await prisma.userPlant.findUnique({
       where: {
         id: req.params.id,
         userId: req.user!.id
       },
-      include: { growthLogs: true }
+      include: { 
+        monthlyPlant: true
+      }
     });
     
-    if (!plant) {
+    if (!userPlant) {
       return res.status(404).json({ message: 'Plant not found' });
     }
     
-    res.json(plant);
+    // Calculate current contributions for this plant
+    const currentContributions = await calculatePlantContributions(req.params.id, req.user!.id, userPlant.plantedAt);
+    
+    res.json({
+      ...userPlant,
+      currentContributions,
+      currentImageUrl: getCurrentStageImageUrl(userPlant.monthlyPlant.imageUrls, userPlant.stage)
+    });
   } catch (error) {
     res.status(500).json({ message: 'Error fetching plant' });
   }
 };
 
-// Create a new plant
+// Create a new plant (based on current month's MonthlyPlant)
 export const createPlant = async (req: AuthRequest, res: Response) => {
   try {
-    const { name, imageUrls } = req.body;
+    const { monthlyPlantId } = req.body;
     
-    if (!name) {
-      return res.status(400).json({ message: 'Plant name is required' });
+    if (!monthlyPlantId) {
+      return res.status(400).json({ message: 'Monthly plant ID is required' });
     }
     
-    // Validate imageUrls array (should have 5 images for all growth stages)
-    if (!imageUrls || !Array.isArray(imageUrls) || imageUrls.length !== 5) {
-      return res.status(400).json({ 
-        message: 'imageUrls array with exactly 5 images is required (SEED, SPROUT, GROWING, MATURE, HARVEST)' 
-      });
+    // Check if monthly plant exists
+    const monthlyPlant = await prisma.monthlyPlant.findUnique({
+      where: { id: parseInt(monthlyPlantId) }
+    });
+    
+    if (!monthlyPlant) {
+      return res.status(404).json({ message: 'Monthly plant not found' });
     }
     
-    const plant = await prisma.plant.create({
+    // Check if user already has a plant for this month/year
+    const currentDate = new Date();
+    const currentMonth = currentDate.getMonth() + 1;
+    const currentYear = currentDate.getFullYear();
+    
+    // Only allow planting current month's plant
+    if (monthlyPlant.month !== currentMonth || monthlyPlant.year !== currentYear) {
+      return res.status(400).json({ message: 'You can only plant the current month\'s plant' });
+    }
+    
+    const userPlant = await prisma.userPlant.create({
       data: {
-        name,
         userId: req.user!.id,
-        imageUrls: imageUrls,
-        stage: 'SEED',
-        currentContributions: 0
+        monthlyPlantId: parseInt(monthlyPlantId),
+        stage: 'SEED'
+      },
+      include: {
+        monthlyPlant: true
       }
     });
     
-    res.status(201).json(plant);
+    res.status(201).json(userPlant);
   } catch (error) {
     res.status(500).json({ message: 'Error creating plant' });
   }
 };
 
-// Update plant
+// Update plant - only stage can be manually updated now
 export const updatePlant = async (req: AuthRequest, res: Response) => {
   try {
-    const { name } = req.body;
+    const { stage } = req.body;
     
     // Check if plant exists and belongs to user
-    const existingPlant = await prisma.plant.findUnique({
+    const existingPlant = await prisma.userPlant.findUnique({
       where: {
         id: req.params.id,
         userId: req.user!.id
@@ -93,12 +195,23 @@ export const updatePlant = async (req: AuthRequest, res: Response) => {
       return res.status(404).json({ message: 'Plant not found' });
     }
     
-    const updatedPlant = await prisma.plant.update({
+    const updatedPlant = await prisma.userPlant.update({
       where: { id: req.params.id },
-      data: { name }
+      data: { 
+        ...(stage && { stage })
+      },
+      include: {
+        monthlyPlant: true
+      }
     });
     
-    res.json(updatedPlant);
+    // Calculate current contributions for response
+    const currentContributions = await calculatePlantContributions(req.params.id, req.user!.id, existingPlant.plantedAt);
+    
+    res.json({
+      ...updatedPlant,
+      currentContributions
+    });
   } catch (error) {
     res.status(500).json({ message: 'Error updating plant' });
   }
@@ -108,7 +221,7 @@ export const updatePlant = async (req: AuthRequest, res: Response) => {
 export const deletePlant = async (req: AuthRequest, res: Response) => {
   try {
     // Check if plant exists and belongs to user
-    const plant = await prisma.plant.findUnique({
+    const plant = await prisma.userPlant.findUnique({
       where: {
         id: req.params.id,
         userId: req.user!.id
@@ -119,7 +232,7 @@ export const deletePlant = async (req: AuthRequest, res: Response) => {
       return res.status(404).json({ message: 'Plant not found' });
     }
     
-    await prisma.plant.delete({
+    await prisma.userPlant.delete({
       where: { id: req.params.id }
     });
     
@@ -129,45 +242,90 @@ export const deletePlant = async (req: AuthRequest, res: Response) => {
   }
 };
 
-// Add growth log to a plant
-export const addGrowthLog = async (req: AuthRequest, res: Response) => {
+// Auto-update plant growth based on GitHub activities
+export const updatePlantGrowth = async (req: AuthRequest, res: Response) => {
   try {
-    const { log, count } = req.body;
-    const { plantId } = req.params;
+    const { userPlantId } = req.params;
     
     // Check if plant exists and belongs to user
-    const plant = await prisma.plant.findUnique({
+    const userPlant = await prisma.userPlant.findUnique({
       where: {
-        id: plantId,
+        id: userPlantId,
         userId: req.user!.id
+      },
+      include: {
+        monthlyPlant: true
       }
     });
     
-    if (!plant) {
+    if (!userPlant) {
       return res.status(404).json({ message: 'Plant not found' });
     }
     
-    const growthLog = await prisma.growthLog.create({
-      data: {
-        plantId,
-        log,
-        count
-      }
-    });
+    // Calculate current contributions from GitHub activities
+    const currentContributions = await calculatePlantContributions(userPlantId, req.user!.id, userPlant.plantedAt);
     
-    // Update plant's currentContributions
-    await prisma.plant.update({
-      where: { id: plantId },
-      data: { 
-        currentContributions: plant.currentContributions + count,
-        // Update stage based on new contribution count if needed
-        stage: determineGrowthStage(plant.currentContributions + count)
-      }
-    });
-    
-    res.status(201).json(growthLog);
+    // Check if harvest is reached (70+ contributions)
+    if (currentContributions >= 70 && userPlant.stage !== 'HARVEST') {
+      // Handle harvest
+      const harvestResult = await handleHarvest(userPlant, req.user!.id);
+      res.json(harvestResult);
+    } else {
+      // Normal growth progression
+      const newStage = determineGrowthStage(currentContributions);
+      const updatedPlant = await prisma.userPlant.update({
+        where: { id: userPlantId },
+        data: { stage: newStage }
+      });
+      
+      res.json({
+        ...updatedPlant,
+        currentContributions,
+        currentImageUrl: getCurrentStageImageUrl(userPlant.monthlyPlant.imageUrls, newStage)
+      });
+    }
   } catch (error) {
-    res.status(500).json({ message: 'Error creating growth log' });
+    res.status(500).json({ message: 'Error updating plant growth' });
+  }
+};
+
+// Get current month's available plant
+export const getCurrentMonthPlant = async (req: AuthRequest, res: Response) => {
+  try {
+    const currentDate = new Date();
+    const currentMonth = currentDate.getMonth() + 1;
+    const currentYear = currentDate.getFullYear();
+    
+    const monthlyPlant = await prisma.monthlyPlant.findFirst({
+      where: {
+        month: currentMonth,
+        year: currentYear
+      }
+    });
+    
+    if (!monthlyPlant) {
+      return res.status(404).json({ message: 'No plant available for current month' });
+    }
+    
+    // Check if user has any plants for this month
+    const existingUserPlants = await prisma.userPlant.findMany({
+      where: {
+        userId: req.user!.id,
+        monthlyPlantId: monthlyPlant.id
+      },
+      orderBy: {
+        plantedAt: 'desc'
+      }
+    });
+    
+    res.json({
+      monthlyPlant,
+      userPlants: existingUserPlants,
+      totalPlanted: existingUserPlants.length,
+      canPlantMore: true // 수확 후 재심기 가능
+    });
+  } catch (error) {
+    res.status(500).json({ message: 'Error fetching current month plant' });
   }
 };
 
@@ -181,14 +339,7 @@ function determineGrowthStage(contributions: number): 'SEED' | 'SPROUT' | 'GROWI
 }
 
 // Helper function to get current stage image URL
-function getCurrentStageImageUrl(imageUrls: string[], stage: 'SEED' | 'SPROUT' | 'GROWING' | 'MATURE' | 'HARVEST'): string {
-  const stageIndex = {
-    'SEED': 0,
-    'SPROUT': 1,
-    'GROWING': 2,
-    'MATURE': 3,
-    'HARVEST': 4
-  };
-  
-  return imageUrls[stageIndex[stage]] || '';
+function getCurrentStageImageUrl(imageUrls: string[], stage: string): string {
+  const stageIndex = ['SEED', 'SPROUT', 'GROWING', 'MATURE', 'HARVEST'].indexOf(stage);
+  return imageUrls[stageIndex] || imageUrls[0];
 } 

--- a/src/routes/gardenRoutes.ts
+++ b/src/routes/gardenRoutes.ts
@@ -6,6 +6,7 @@ import {
     getMonthlyPlants,
     getUserBadges,
     getUserItems,
+    getUserCrops,
     purchaseItem
 } from '@/controllers/item/gardenController';
 import { clientAuth } from '@/middlewares/authMiddleware';
@@ -28,6 +29,9 @@ router.get('/items/:id', getGardenItemById);
 
 // Get user's items
 router.get('/user-items', getUserItems);
+
+// Get user's crops specifically
+router.get('/user-crops', getUserCrops);
 
 // Purchase item for user
 router.post('/user-items', purchaseItem);

--- a/src/routes/plantRoutes.ts
+++ b/src/routes/plantRoutes.ts
@@ -1,4 +1,4 @@
-import { addGrowthLog, createPlant, deletePlant, getPlantById, getPlants, updatePlant } from '@/controllers/item/plantController';
+import { updatePlantGrowth, createPlant, deletePlant, getPlantById, getPlants, updatePlant, getCurrentMonthPlant } from '@/controllers/item/plantController';
 import { clientAuth } from '@/middlewares/authMiddleware';
 import express from 'express';
 
@@ -6,6 +6,9 @@ const router = express.Router();
 
 // Apply authentication middleware to all routes
 router.use(clientAuth);
+
+// Get current month's available plant
+router.get('/current-month', getCurrentMonthPlant);
 
 // Get all user's plants
 router.get('/', getPlants);
@@ -22,8 +25,8 @@ router.put('/:id', updatePlant);
 // Delete plant
 router.delete('/:id', deletePlant);
 
-// Growth Logs
-// Add growth log to a plant
-router.post('/:plantId/logs', addGrowthLog);
+// Plant Growth Update
+// Update plant growth based on GitHub activities
+router.post('/:userPlantId/update-growth', updatePlantGrowth);
 
 export default router; 


### PR DESCRIPTION
## Title
feat: restructure plant system with monthly logic, GitHub-based growth, and admin upload support

## Purpose
- Refactor the plant growth system to support monthly plants and GitHub-driven mechanics
- Improve admin workflows by modularizing upload logic and updating schema consistency

## Changes
## Prisma Schema & DB
- Replaced `Plant` with `UserPlant` for user-specific plant management
- Added `MonthlyPlant` model with `imageUrls` array and `iconUrl` field
- Added `harvestCount` to `UserPlant`
- Updated `GrowthLog` to reference `UserPlant` instead of `Plant`
- Enforced unique constraint on (`month`, `year`) in `MonthlyPlant`
- Removed `Plant` table and related foreign keys

## Upload Controller
- Split upload controller into type-specific modules
- Rebuilt `plantUploadController` to handle main, icon, and growth stage image uploads
- Structured upload response for `MonthlyPlant` creation
- Deprecated `uploadCropImage` endpoint with warning message

## GitHub Growth System
- Implemented contribution-based growth logic
- Auto-harvest when reaching contribution threshold (70+)
- Generated crop items and added to user inventory
- Validated monthly planting logic
- Added new endpoints:
  - `/user-crops`
  - `/current-month`
  - `/:userPlantId/update-growth`
- Removed legacy growth log routes

## Admin Updates
- Added `SuperUser` validation to all admin routes
- Updated admin monthly plant endpoints to support new fields
- Unified response structure and validation logic
- Updated admin stats to use `UserPlant` data