### PR TITLE
feat: add getUpdateNoteById endpoint for admin access

### DIFF
--- a/src/controllers/admin/updateNoteController.ts
+++ b/src/controllers/admin/updateNoteController.ts
@@ -20,6 +20,21 @@ export const getUpdateNotes = async (req: AuthRequest, res: Response) => {
   }
 };
 
+export const getUpdateNoteById = async (req: AuthRequest, res: Response) => {
+  try {
+    const updateNote = await prisma.updateNote.findUnique({
+      where: { id: parseInt(req.params.id) }
+    });
+    if (!updateNote) {
+      return res.status(404).json({ message: 'Update note not found' });
+    }
+    
+    res.json(updateNote);
+  } catch (error) {
+    res.status(500).json({ message: 'Error fetching update note' });
+  }
+} 
+
 export const createUpdateNote = async (req: AuthRequest, res: Response) => {
   try {
     const { title, description, imageUrl, month, year, gardenItemIds } = req.body;

--- a/src/routes/adminRoutes.ts
+++ b/src/routes/adminRoutes.ts
@@ -1,7 +1,7 @@
 import { createAdminUser, deleteAdminUser, getAdminSession, getAdminStats, getAdminUsers } from '@/controllers/admin/adminController';
 import { createBadge, createGardenItem, updateBadge, updateGardenItem } from '@/controllers/admin/itemController';
 import { createMonthlyPlant, deleteMonthlyPlant, getMonthlyPlantById, updateMonthlyPlant } from '@/controllers/admin/monthlyPlantController';
-import { createUpdateNote, deleteUpdateNote, getUpdateNotes, updateUpdateNote } from '@/controllers/admin/updateNoteController';
+import { createUpdateNote, deleteUpdateNote, getUpdateNoteById, getUpdateNotes, updateUpdateNote } from '@/controllers/admin/updateNoteController';
 import { getBadges, getGardenItems, getMonthlyPlants } from '@/controllers/item/gardenController';
 import { adminAuth, logout } from '@/middlewares/authMiddleware';
 import express from 'express';
@@ -39,6 +39,7 @@ router.put('/badges/:id', updateBadge);
 
 // UPDATE NOTE MANAGEMENT
 router.get('/update-notes', getUpdateNotes);
+router.get('/update-notes/:id', getUpdateNoteById);
 router.post('/update-notes', createUpdateNote);
 router.put('/update-notes/:id', updateUpdateNote);
 router.delete('/update-notes/:id', deleteUpdateNote);


### PR DESCRIPTION
## Title  
feat: add getUpdateNoteById endpoint for admin access

## Purpose  
- To enable ID-based fetch of update-notes for full CRUD support in admin page.

## Changes  
- Added `getUpdateNoteById` in `updateNoteController` to fetch a single update note, and added `GET /admin/update-notes/:id` route in `adminRoutes.ts`