### PR TITLE
feat: add public API endpoints for unauthenticated users on landing and shop pages

### DIFF
--- a/src/controllers/item/gardenController.ts
+++ b/src/controllers/item/gardenController.ts
@@ -276,6 +276,44 @@ export const getCurrentUpdate = async (req: Request, res: Response) => {
   }
 };
 
+// Get current month's update note and new items only (for shop page)
+export const getCurrentUpdateNote = async (req: Request, res: Response) => {
+  try {
+    const currentDate = new Date();
+    const currentMonth = currentDate.getMonth() + 1;
+    const currentYear = currentDate.getFullYear();
+    
+    // Get current month's update note
+    const updateNote = await prisma.updateNote.findFirst({
+      where: {
+        month: currentMonth,
+        year: currentYear,
+        isActive: true
+      },
+      include: {
+        gardenItems: true
+      }
+    });
+    
+    // Prepare response (only update note and new items, no monthly plant)
+    const response = {
+      month: currentMonth,
+      year: currentYear,
+      updateNote: updateNote ? {
+        id: updateNote.id,
+        title: updateNote.title,
+        description: updateNote.description,
+        imageUrl: updateNote.imageUrl
+      } : null,
+      newItems: updateNote?.gardenItems || []
+    };
+    
+    res.json(response);
+  } catch (error) {
+    res.status(500).json({ message: 'Error fetching current update note' });
+  }
+};
+
 // Get update history
 export const getUpdateHistory = async (req: AuthRequest, res: Response) => {
   try {

--- a/src/routes/publicRoutes.ts
+++ b/src/routes/publicRoutes.ts
@@ -1,0 +1,12 @@
+import { getCurrentUpdateNote, getMonthlyPlants } from '@/controllers/item/gardenController';
+import express from 'express';
+
+const router = express.Router();
+
+// 당월 월간 식물 소개 노트 (소개페이지용)
+router.get('/monthly-plant', getMonthlyPlants);
+
+// 현재 월의 업데이트 노트와 신규 아이템 (상점페이지용)
+router.get('/current-update', getCurrentUpdateNote);
+
+export default router; 

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import plantRoutes from './routes/plantRoutes';
 import seedRoutes from './routes/seedRoutes';
 import uploadRoutes from './routes/uploadRoutes';
 import userRoutes from './routes/userRoutes';
+import publicRoutes from './routes/publicRoutes';
 
 dotenv.config();
 const app = express();
@@ -37,6 +38,7 @@ app.use('/api/seeds', seedRoutes);
 app.use('/api/garden', gardenRoutes);
 app.use('/api/admin', adminRoutes);
 app.use('/api/upload', uploadRoutes);
+app.use('/api/public', publicRoutes);
 
 // Error handling
 app.use((err: Error, req: express.Request, res: express.Response, next: express.NextFunction) => {


### PR DESCRIPTION
## Title
feat: add public API endpoints for unauthenticated users on landing and shop pages

## Purpose
- To support unauthenticated users by adding public API routes needed for the landing and shop pages.

## Changes
- Added `GET /api/public/monthly-plant`: Provides intro info for the monthly plant (used in the landing page)
- Added `GET /api/public/current-update`: Returns current update note and new garden items (used in the shop page)
- Created `src/routes/publicRoutes.ts` to manage public-facing endpoints
- Registered `publicRoutes` in `src/server.ts`