### PR TITLE
fix: allow all background modes including default in equipped items filter

### DIFF
--- a/src/controllers/auth/userController.ts
+++ b/src/controllers/auth/userController.ts
@@ -54,7 +54,7 @@ export const getUserProfile = async (req: AuthRequest, res: Response) => {
     // Separate equipped items by category - return all equipped items
     const equippedBackgrounds = equippedItems.filter(item => 
       item.item.category === 'background' &&
-      (item.item.mode === 'GARDEN' || item.item.mode === 'MINI')  // 배경화면은 GARDEN 또는 MINI 모드
+      item.item.mode // 모드 조건 추가 (default 포함 - 공용 모드로 설정)
     ).map(item => item.item);
     
     const equippedPots = equippedItems.filter(item => 


### PR DESCRIPTION
## Title
fix: allow all background modes including default in equipped items filter

## Purpose
- Fix an issue where background items with the `default` mode were not shown in the Client page,  
  even though they were correctly returned by the API (visible in Network tab).  
- This was due to filtering logic that excluded `default` mode items.

## Changes
- Updated filter logic in `equippedBackgrounds` to include all `item.mode` values,  
  allowing backgrounds set to `default` (mode) to appear properly