### PR TITLE
fix: restrict userPlant auto-update to current month's plant only

### DIFF
--- a/src/controllers/auth/userController.ts
+++ b/src/controllers/auth/userController.ts
@@ -40,8 +40,20 @@ export async function autoUpdateAllUserPlants(userId: string) {
   try {
     const monthlyContributions = await calculateMonthlyContributions(userId);
     
+    // Get current month and year
+    const currentDate = new Date();
+    const currentMonth = currentDate.getMonth() + 1;
+    const currentYear = currentDate.getFullYear();
+    
+    // Only get current month's plants
     const activePlants = await prisma.userPlant.findMany({
-      where: { userId },
+      where: { 
+        userId,
+        monthlyPlant: {
+          month: currentMonth,
+          year: currentYear
+        }
+      },
       include: { monthlyPlant: true },
       orderBy: { updatedAt: 'desc' }
     });


### PR DESCRIPTION
## Title
fix: restrict userPlant auto-update to current month's plant only

## Purpose
Ensure that the auto-update logic for user plants **only applies to the plant for the current month**, in order to prevent incorrect updates to plants from previous months.

## Changes
- Updated the query in `autoUpdateAllUserPlants` to **only select the plant for the current month and year**
- Prevented growth stage and harvest data from being applied to outdated userPlants
- Improved data consistency and avoided unexpected behavior in the `/profile` API response