### PR TITLE
feat: add missing delete item endpoint for admin CRUD

### DIFF
--- a/src/controllers/admin/itemController.ts
+++ b/src/controllers/admin/itemController.ts
@@ -87,6 +87,18 @@ export const updateGardenItem = async (req: AuthRequest, res: Response) => {
   }
 };
 
+export const deleteGardenItem = async (req: AuthRequest, res: Response) => {
+  try {
+    await prisma.gardenItem.delete({
+      where: { id: parseInt(req.params.id) }
+    });
+    res.status(200).json({ message: 'Item deleted successfully' });
+  } catch (error) {
+    console.error('Garden item deletion error:', error);
+    res.status(500).json({ message: 'Error deleting item' });
+  }
+};
+
 // for badge
 export const getBadges = async (req: AuthRequest, res: Response) => {
   try {

--- a/src/routes/adminRoutes.ts
+++ b/src/routes/adminRoutes.ts
@@ -1,5 +1,5 @@
 import { createAdminUser, deleteAdminUser, getAdminSession, getAdminStats, getAdminUsers } from '@/controllers/admin/adminController';
-import { createBadge, createGardenItem, updateBadge, updateGardenItem } from '@/controllers/admin/itemController';
+import { createBadge, createGardenItem, deleteGardenItem, updateBadge, updateGardenItem } from '@/controllers/admin/itemController';
 import { createMonthlyPlant, deleteMonthlyPlant, getMonthlyPlantById, updateMonthlyPlant } from '@/controllers/admin/monthlyPlantController';
 import { createUpdateNote, deleteUpdateNote, getUpdateNoteById, getUpdateNotes, updateUpdateNote } from '@/controllers/admin/updateNoteController';
 import { getBadges, getGardenItemById, getGardenItems, getMonthlyPlants } from '@/controllers/item/gardenController';
@@ -32,6 +32,7 @@ router.get('/items', getGardenItems);
 router.get('/items/:id', getGardenItemById);
 router.post('/items', createGardenItem);
 router.put('/items/:id', updateGardenItem);
+router.delete('/items/:id', deleteGardenItem);
 
 // BADGE MANAGEMENT
 router.get('/badges', getBadges);


### PR DESCRIPTION
## Title
feat: add missing delete item endpoint for admin CRUD

## Purpose
- During admin CRUD testing, I noticed the delete function failed with a 404 — the API route was missing.

## Changes
- Implemented `deleteGardenItem` controller
- Added `DELETE /admin/items/:id` route to the admin API

## Optional
> Note to self: Don’t forget endpoints next time...