### PR TITLE
fix: fix uploaded item name issue, remove unused code in upload API

### DIFF
--- a/src/controllers/upload/badgeUploadController.ts
+++ b/src/controllers/upload/badgeUploadController.ts
@@ -1,9 +1,6 @@
-import { PrismaClient } from '@prisma/client';
 import { Response } from 'express';
 import { AuthRequest } from '@/types/auth';
 import { uploadToCloudinary } from './uploadController';
-
-const prisma = new PrismaClient();
 
 // upload badge image
 export const uploadBadgeImage = async (req: AuthRequest, res: Response) => {

--- a/src/controllers/upload/gardenItemUploadController.ts
+++ b/src/controllers/upload/gardenItemUploadController.ts
@@ -14,6 +14,7 @@ export const uploadBackgroundImage = async (req: AuthRequest, res: Response) => 
       return res.status(400).json({ message: 'Main image and icon image are required' });
     }
 
+    const name = req.body.name || files.mainImage[0].originalname;
     const mainFilename = req.body.mainFilename || files.mainImage[0].originalname;
     const iconFilename = req.body.iconFilename || files.iconImage[0].originalname;
     const mode = req.body.mode || 'DEFAULT';
@@ -43,7 +44,7 @@ export const uploadBackgroundImage = async (req: AuthRequest, res: Response) => 
 
     const gardenItem = await prisma.gardenItem.create({
       data: {
-        name: mainFilename,
+        name: name,
         category: 'background',
         imageUrl: mainResult.secure_url,
         iconUrl: iconResult.secure_url,
@@ -75,6 +76,7 @@ export const uploadPotImage = async (req: AuthRequest, res: Response) => {
       return res.status(400).json({ message: 'Main image and icon image are required' });
     }
 
+    const name = req.body.name || files.mainImage[0].originalname;
     const mainFilename = req.body.mainFilename || files.mainImage[0].originalname;
     const iconFilename = req.body.iconFilename || files.iconImage[0].originalname;
 
@@ -98,7 +100,7 @@ export const uploadPotImage = async (req: AuthRequest, res: Response) => {
 
     const gardenItem = await prisma.gardenItem.create({
       data: {
-        name: mainFilename,
+        name: name,
         category: 'pot',
         imageUrl: mainResult.secure_url,
         iconUrl: iconResult.secure_url,

--- a/src/controllers/upload/plantUploadController.ts
+++ b/src/controllers/upload/plantUploadController.ts
@@ -1,8 +1,6 @@
-import { PrismaClient } from '@prisma/client';
 import { Response } from 'express';
 import { AuthRequest } from '@/types/auth';
 import { PLANT_STAGES, uploadToCloudinary } from './uploadController';
-
 
 // upload plant images
 export const uploadPlantImage = async (req: AuthRequest, res: Response) => {
@@ -76,15 +74,3 @@ export const uploadPlantImage = async (req: AuthRequest, res: Response) => {
     res.status(500).json({ message: 'Image upload failed' });
   }
 };
-
-// upload crop image - 이 함수는 이제 사용하지 않을 예정이지만 호환성을 위해 유지
-export const uploadCropImage = async (req: AuthRequest, res: Response) => {
-  try {
-    return res.status(400).json({ 
-      message: 'This endpoint is deprecated. Please use MonthlyPlant creation instead.' 
-    });
-  } catch (error) {
-    console.error('Plant image upload error:', error);
-    res.status(500).json({ message: 'Image upload failed' });
-  }
-}; 

--- a/src/controllers/upload/updateNoteUploadController.ts
+++ b/src/controllers/upload/updateNoteUploadController.ts
@@ -1,9 +1,6 @@
-import { PrismaClient } from '@prisma/client';
 import { Response } from 'express';
 import { AuthRequest } from '@/types/auth';
 import { uploadToCloudinary } from './uploadController';
-
-const prisma = new PrismaClient();
 
 // upload update note image
 export const uploadUpdateNoteImage = async (req: AuthRequest, res: Response) => {

--- a/src/routes/uploadRoutes.ts
+++ b/src/routes/uploadRoutes.ts
@@ -1,5 +1,5 @@
 import { upload } from '@/controllers/upload/uploadController';
-import { uploadPlantImage, uploadCropImage } from '@/controllers/upload/plantUploadController';
+import { uploadPlantImage } from '@/controllers/upload/plantUploadController';
 import { uploadBackgroundImage, uploadPotImage } from '@/controllers/upload/gardenItemUploadController';
 import { uploadBadgeImage } from '@/controllers/upload/badgeUploadController';
 import { uploadUpdateNoteImage } from '@/controllers/upload/updateNoteUploadController';
@@ -21,9 +21,6 @@ router.post('/plants', upload.fields([
   { name: 'mature', maxCount: 1 },
   { name: 'harvest', maxCount: 1 }
 ]), uploadPlantImage);
-
-// upload crop image
-router.post('/crops', upload.single('image'), uploadCropImage);
 
 // upload background image
 router.post('/backgrounds', upload.fields([


### PR DESCRIPTION
## Title
fix: fix uploaded item name issue, remove unused code in upload API

## Purpose
- While working on the admin page, I noticed that an uploaded item was being inserted into the DB twice.
- The root cause was that the backend upload API already stores the item, while the admin client redundantly called `/items`.
- Since the admin no longer calls `/items`, the only remaining issue was the item name being saved incorrectly.
- This PR fixes that by ensuring `req.body.name` is used instead of the file name.

## Changes
### Bug Fix
- Fixed issue where uploaded item name was incorrectly saved from file name
- Now uses `req.body.name` for item name consistently

### Cleanup
- Removed unused `/crops` route and its controller function
- Removed unused `PrismaClient` instance in `uploadRoutes`

## Optional
> Considering whether to refactor for SRP or keep current flow to reduce API calls