### PR TITLE
feat: implement API endpoints for shop page and improve existing item logic

### DIFF
--- a/src/controllers/item/seedController.ts
+++ b/src/controllers/item/seedController.ts
@@ -43,15 +43,16 @@ export const addSeeds = async (req: AuthRequest, res: Response) => {
   }
 };
 
-// Use seeds
+// Use seeds (optionally to purchase item)
 export const useSeeds = async (req: AuthRequest, res: Response) => {
   try {
-    const { count } = req.body;
+    const { count, itemId } = req.body;
     
     if (!count || count <= 0) {
       return res.status(400).json({ message: 'Valid seed count is required' });
     }
-    
+
+    // Check if user has enough seeds
     const seed = await prisma.seed.findUnique({
       where: { userId: req.user!.id }
     });
@@ -59,17 +60,73 @@ export const useSeeds = async (req: AuthRequest, res: Response) => {
     if (!seed || seed.count < count) {
       return res.status(400).json({ message: 'Not enough seeds' });
     }
-    
-    const updatedSeed = await prisma.seed.update({
-      where: { userId: req.user!.id },
-      data: {
-        count: {
-          decrement: count
-        }
+
+    // If itemId is provided, this is a purchase request
+    if (itemId) {
+      // Check if item exists
+      const item = await prisma.gardenItem.findUnique({
+        where: { id: parseInt(itemId) }
+      });
+      
+      if (!item) {
+        return res.status(404).json({ message: 'Garden item not found' });
       }
-    });
-    
-    res.json(updatedSeed);
+
+      // Check if user already has this item
+      const existingItem = await prisma.userItem.findFirst({
+        where: {
+          userId: req.user!.id,
+          itemId: parseInt(itemId)
+        }
+      });
+      
+      if (existingItem) {
+        return res.status(400).json({ message: 'You already own this item' });
+      }
+
+      // Transaction to deduct seeds and add item
+      const result = await prisma.$transaction(async (tx) => {
+        const updatedSeed = await tx.seed.update({
+          where: { userId: req.user!.id },
+          data: {
+            count: {
+              decrement: count
+            }
+          }
+        });
+
+        const userItem = await tx.userItem.create({
+          data: {
+            userId: req.user!.id,
+            itemId: parseInt(itemId),
+            equipped: false
+          },
+          include: {
+            item: true
+          }
+        });
+
+        return { updatedSeed, userItem };
+      });
+
+      
+      res.json({
+        seeds: result.updatedSeed,
+        purchasedItem: result.userItem
+      });
+    } else {
+      // Simple seed usage without purchase
+      const updatedSeed = await prisma.seed.update({
+        where: { userId: req.user!.id },
+        data: {
+          count: {
+            decrement: count
+          }
+        }
+      });
+
+      res.json(updatedSeed);
+    }
   } catch (error) {
     res.status(500).json({ message: 'Error using seeds' });
   }

--- a/src/routes/publicRoutes.ts
+++ b/src/routes/publicRoutes.ts
@@ -1,4 +1,4 @@
-import { getCurrentUpdateNote, getMonthlyPlants } from '@/controllers/item/gardenController';
+import { getCurrentUpdateNote, getMonthlyPlants, getGardenItems } from '@/controllers/item/gardenController';
 import express from 'express';
 
 const router = express.Router();
@@ -8,5 +8,8 @@ router.get('/monthly-plant', getMonthlyPlants);
 
 // 현재 월의 업데이트 노트와 신규 아이템 (상점페이지용)
 router.get('/current-update', getCurrentUpdateNote);
+
+// 모든 garden 아이템 조회 (상점페이지용)
+router.get('/items', getGardenItems);
 
 export default router; 


### PR DESCRIPTION
## Title
feat: implement API endpoints for shop page and improve existing item logic

## Purpose
- To support the shop page, this PR adds a public route to fetch all garden items and introduces item purchase functionality using seeds.
- Previously, seeds were deducted without actually granting the purchased item to the user.
- While handling MyPage data, I noticed only equipped items were returned, making it difficult to render the full item list.
- To clarify the role of `equipped`, I added a new response field (`allUserItems`) and improved the equip logic for better consistency.

## Changes
### Shop API
- Added `GET /items` public route to retrieve all garden items
- Implemented item purchase using seeds with transaction and validation (e.g., insufficient seeds, duplicates, invalid item)

### MyPage Improvements
- Added full item list to user profile response
- Clarified equip/unequip logic and included item change details
- Improved error logging and code readability