### PR TITLE
refactor: use select in garden item queries to prevent exposing superuser ID

### DIFF
--- a/src/controllers/item/gardenController.ts
+++ b/src/controllers/item/gardenController.ts
@@ -277,7 +277,9 @@ export const getCurrentUpdate = async (req: Request, res: Response) => {
         isActive: true
       },
       include: {
-        gardenItems: true
+        gardenItems: {
+          select: gardenItemSelect
+        }
       }
     });
     
@@ -324,7 +326,9 @@ export const getCurrentUpdateNote = async (req: Request, res: Response) => {
         isActive: true
       },
       include: {
-        gardenItems: true
+        gardenItems: {
+          select: gardenItemSelect
+        }
       }
     });
     
@@ -357,7 +361,9 @@ export const getUpdateHistory = async (req: AuthRequest, res: Response) => {
         isActive: true
       },
       include: {
-        gardenItems: true
+        gardenItems: {
+          select: gardenItemSelect
+        }
       },
       orderBy: [
         { year: 'desc' },


### PR DESCRIPTION
## Title
refactor: use select in garden item queries to prevent exposing superuser ID

## Purpose
- While developing the client page, I noticed that internal admin data such as `updatedById` (Superuser ID) was being unintentionally exposed through overly broad `include` queries.
- To resolve this, we replaced `include` with `select` to explicitly define the fields returned in API responses, improving overall data safety.

## Changes
- Defined `gardenItemSelect` in `db.ts` to explicitly control exposed fields (admin-only fields excluded)
- Replaced `include` with `select` in:
  - `userController.ts`
  - `gardenController.ts`
- Maintained consistency with existing access control logic for admin-only fields

## Effect
- `updatedById` is no longer exposed to regular users
- Only the explicitly defined fields in `gardenItemSelect` are returned in API responses