### PR TITLE
feat: implement crop system with UserCrop model and enhanced MonthlyPlant in Prisma

### DIFF
--- a/prisma/migrations/20250726065143_add_crop_system/migration.sql
+++ b/prisma/migrations/20250726065143_add_crop_system/migration.sql
@@ -1,0 +1,37 @@
+/*
+  Warnings:
+
+  - Added the required column `cropImageUrl` to the `MonthlyPlant` table without a default value. This is not possible if the table is not empty.
+  - Made the column `iconUrl` on table `MonthlyPlant` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "MonthlyPlant" ADD COLUMN     "cropImageUrl" TEXT NOT NULL,
+ALTER COLUMN "iconUrl" SET NOT NULL;
+
+-- CreateTable
+CREATE TABLE "UserCrop" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "monthlyPlantId" INTEGER NOT NULL,
+    "quantity" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserCrop_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "UserCrop_userId_idx" ON "UserCrop"("userId");
+
+-- CreateIndex
+CREATE INDEX "UserCrop_monthlyPlantId_idx" ON "UserCrop"("monthlyPlantId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserCrop_userId_monthlyPlantId_key" ON "UserCrop"("userId", "monthlyPlantId");
+
+-- AddForeignKey
+ALTER TABLE "UserCrop" ADD CONSTRAINT "UserCrop_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserCrop" ADD CONSTRAINT "UserCrop_monthlyPlantId_fkey" FOREIGN KEY ("monthlyPlantId") REFERENCES "MonthlyPlant"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
   updatedAt        DateTime         @updatedAt
   githubActivities GitHubActivity[]
   userPlants       UserPlant[]
+  userCrops        UserCrop[]
   seeds            Seed?
   refreshTokens    RefreshToken[]
   superUser        SuperUser?
@@ -115,7 +116,8 @@ model MonthlyPlant {
   name        String
   description String
   imageUrls   String[]
-  iconUrl     String?
+  iconUrl     String
+  cropImageUrl String
   month       Int
   year        Int
   createdAt   DateTime   @default(now())
@@ -124,8 +126,25 @@ model MonthlyPlant {
   id          Int        @id @default(autoincrement())
   updatedBy   SuperUser? @relation("MonthlyPlantUpdatedBy", fields: [updatedById], references: [id])
   userPlants  UserPlant[]
+  userCrops   UserCrop[]
 
   @@unique([month, year])
+}
+
+model UserCrop {
+  id              String   @id @default(cuid())
+  userId          String
+  monthlyPlantId  Int      // MonthlyPlant 직접 참조
+  quantity        Int      @default(0)
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  
+  user            User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  monthlyPlant    MonthlyPlant @relation(fields: [monthlyPlantId], references: [id], onDelete: Cascade)
+  
+  @@unique([userId, monthlyPlantId])  // 한 사용자당 같은 MonthlyPlant는 하나의 작물만
+  @@index([userId])
+  @@index([monthlyPlantId])
 }
 
 model SuperUser {


### PR DESCRIPTION
## Title  
feat: implement crop system with UserCrop model and enhanced MonthlyPlant in Prisma

## Purpose
- Add user-specific crop tracking and update `MonthlyPlant` to support crop display with stricter field validation

## Changes
### Prisma Schema & Models
- Add `UserCrop` model for per-user crop tracking
- Update `MonthlyPlant` model:
  - Add `cropImageUrl` field
  - Make `iconUrl` required
- Define relations among `User`, `MonthlyPlant`, and `UserCrop`

### Migration
- Add migration file: `20250726065143_add_crop_system`

## Effect
- Backend support for crop-related features (e.g., tracking, displaying)
- Improved schema safety and structure consistency