### PR TITLE
feat: support crop image upload for MonthlyPlant creation and update

### DIFF
--- a/src/controllers/admin/monthlyPlantController.ts
+++ b/src/controllers/admin/monthlyPlantController.ts
@@ -34,7 +34,7 @@ export const getMonthlyPlantById = async (req: AuthRequest, res: Response) => {
 
 export const createMonthlyPlant = async (req: AuthRequest, res: Response) => {
   try {
-    const { title, name, description, imageUrls, iconUrl, month, year } = req.body;
+    const { title, name, description, imageUrls, iconUrl, cropImageUrl, month, year } = req.body;
     
     if (!title || !name || !description || !imageUrls || !month || !year) {
       return res.status(400).json({ message: 'Title, name, description, imageUrls, month, and year are required' });
@@ -67,6 +67,7 @@ export const createMonthlyPlant = async (req: AuthRequest, res: Response) => {
         description,
         imageUrls,
         iconUrl,
+        cropImageUrl,
         month: parseInt(month),
         year: parseInt(year),
         updatedById: req.superUser!.id
@@ -82,7 +83,7 @@ export const createMonthlyPlant = async (req: AuthRequest, res: Response) => {
 
 export const updateMonthlyPlant = async (req: AuthRequest, res: Response) => {
   try {
-    const { title, name, description, imageUrls, iconUrl } = req.body;
+    const { title, name, description,iconUrl, cropImageUrl, imageUrls } = req.body;
     
     // SuperUser validation is already done in adminAuth middleware
     
@@ -95,6 +96,7 @@ export const updateMonthlyPlant = async (req: AuthRequest, res: Response) => {
     if (name) updateData.name = name;
     if (description) updateData.description = description;
     if (iconUrl) updateData.iconUrl = iconUrl;
+    if (cropImageUrl) updateData.cropImageUrl = cropImageUrl;
     if (imageUrls) {
       if (!Array.isArray(imageUrls) || imageUrls.length !== 5) {
         return res.status(400).json({ 

--- a/src/controllers/upload/plantUploadController.ts
+++ b/src/controllers/upload/plantUploadController.ts
@@ -16,6 +16,10 @@ export const uploadPlantImage = async (req: AuthRequest, res: Response) => {
       return res.status(400).json({ message: 'Icon image is required' });
     }
     
+    if (!files.cropImage?.[0]) {
+      return res.status(400).json({ message: 'Crop image is required' });
+    }
+    
     // Check if all growth stage images are provided
     const missingStages = PLANT_STAGES.filter((stage: string) => !files[stage]?.[0]);
     if (missingStages.length > 0) {
@@ -40,6 +44,15 @@ export const uploadPlantImage = async (req: AuthRequest, res: Response) => {
       'git-plants(plants)',
       'images/plants',
       iconFilename
+    );
+
+    // upload crop image
+    const cropFilename = req.body.cropFilename || files.cropImage[0].originalname;
+    const cropResult = await uploadToCloudinary(
+      files.cropImage[0],
+      'git-plants(crops)',
+      'images/crops',
+      cropFilename
     );
     
     // Parallel upload for growth stage images
@@ -66,7 +79,8 @@ export const uploadPlantImage = async (req: AuthRequest, res: Response) => {
         iconImage: iconResult,
         growthImages: growthImageUrls,
         imageUrls: growthImageUrls, // createMonthlyPlant에서 사용할 수 있도록
-        iconUrl: iconResult.secure_url // createMonthlyPlant에서 사용할 수 있도록
+        iconUrl: iconResult.secure_url, // createMonthlyPlant에서 사용할 수 있도록
+        cropImageUrl: cropResult.secure_url
       } 
     });
   } catch (error) {

--- a/src/routes/uploadRoutes.ts
+++ b/src/routes/uploadRoutes.ts
@@ -15,11 +15,12 @@ router.use(adminAuth);
 router.post('/plants', upload.fields([
   { name: 'mainImage', maxCount: 1 },
   { name: 'iconImage', maxCount: 1 },
+  { name: 'cropImage', maxCount: 1 },
   { name: 'seed', maxCount: 1 },
   { name: 'sprout', maxCount: 1 },
   { name: 'growing', maxCount: 1 },
   { name: 'mature', maxCount: 1 },
-  { name: 'harvest', maxCount: 1 }
+  { name: 'harvest', maxCount: 1 },
 ]), uploadPlantImage);
 
 // upload background image


### PR DESCRIPTION
## Title
feat: support crop image upload for MonthlyPlant creation and update

## Purpose
- Add BE support for uploading and saving crop images (`cropImageUrl`) when creating or updating MonthlyPlant entries.

## Changes
- Handled `cropImageUrl` in MonthlyPlant Controller
- Implemented crop image upload in Plant Upload Controller
- Added `cropImage` field to upload routes