### PR TITLE
feat: implement full crop flow (harvest → storage → sell) and remove recovery logic

### DIFF
--- a/src/routes/gardenRoutes.ts
+++ b/src/routes/gardenRoutes.ts
@@ -7,7 +7,8 @@ import {
     getUserBadges,
     getUserItems,
     getUserCrops,
-    purchaseItem
+    purchaseItem,
+    sellCrops
 } from '@/controllers/item/gardenController';
 import { clientAuth } from '@/middlewares/authMiddleware';
 import express from 'express';
@@ -32,6 +33,9 @@ router.get('/user-items', getUserItems);
 
 // Get user's crops specifically
 router.get('/user-crops', getUserCrops);
+
+// Sell crops for seeds
+router.post('/user-crops/sell', sellCrops);
 
 // Purchase item for user
 router.post('/user-items', purchaseItem);


### PR DESCRIPTION
## Title  
feat: implement full crop flow (harvest → storage → sell) and remove recovery logic

## Purpose  
- Previously, even after a user sold their crops, the auto-update logic would restore them unintentionally.  
- To fix this, the update logic now ensures that harvested crops are stored and sold properly, without being recovered afterwards.  
- Plus, the entry barrier for new users is lowered by allowing them to receive crops based on their existing GitHub contributions—even if they join mid-month—so they can participate in the crop system right away without having to grind from zero.

## Changes  
### auth/userController.ts  
- **Initial Crop Distribution**
  - Removed the recovery condition (`quantity < harvestCount`) from `autoUpdateAllUserPlants`  
  - Crops are now only given if the user has no existing `UserCrop` record  
  - Ensured that even new users get crops based on past contribution count

- **Harvest Logic**
  - Refactored `addCropToUser` using the `UserCrop` model  
  - Added `harvestedAt` timestamp when crops are collected

- **User Profile**
  - Extended `getUserProfile` to include the user’s current crop inventory

### item/gardenController.ts  
- **Crop Lookup**
  - Rebuilt `getUserCrops` to use the `UserCrop` model  
  - Cleaned up crop storage structure for consistency

- **Selling Logic**
  - Implemented `sellCrops` function for selling multiple crops at once  
  - Wrapped the update in a Prisma transaction and issued seed rewards accordingly

### routes/gardenRoutes.ts  
- **API Route**
  - Added `POST /user-crops/sell` endpoint  
  - Accepts crop IDs and seed value payloads from the frontend and handles the sale