### PR TITLE
feat: convert UpdateNote model to active-based publishing system

### DIFF
--- a/prisma/migrations/20250802120456_convert_update_note_to_active_based/migration.sql
+++ b/prisma/migrations/20250802120456_convert_update_note_to_active_based/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `month` on the `UpdateNote` table. All the data in the column will be lost.
+  - You are about to drop the column `year` on the `UpdateNote` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "UpdateNote_month_year_key";
+
+-- AlterTable
+ALTER TABLE "UpdateNote" DROP COLUMN "month",
+DROP COLUMN "year",
+ADD COLUMN     "publishedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "validUntil" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "UpdateNote_publishedAt_idx" ON "UpdateNote"("publishedAt");
+
+-- CreateIndex
+CREATE INDEX "UpdateNote_isActive_idx" ON "UpdateNote"("isActive");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -176,8 +176,8 @@ model UpdateNote {
   title       String
   description String
   imageUrl    String
-  month       Int
-  year        Int
+  publishedAt DateTime     @default(now())
+  validUntil  DateTime?
   isActive    Boolean      @default(true)
   createdAt   DateTime     @default(now())
   updatedAt   DateTime     @updatedAt
@@ -185,7 +185,8 @@ model UpdateNote {
   updatedBy   SuperUser?   @relation("UpdateNoteUpdatedBy", fields: [updatedById], references: [id])
   gardenItems GardenItem[] @relation("GardenItemToUpdateNote")
 
-  @@unique([month, year])
+  @@index([publishedAt])
+  @@index([isActive])
 }
 
 enum GrowthStage {


### PR DESCRIPTION
## Title
feat: convert UpdateNote model to active-based publishing system

## Purpose
- Previously, the client had to manually input the `month` and `year` when creating an UpdateNote, and images would stop displaying when the month changed.
- To simplify this and avoid missing content, I restructured the model to use an active-period system. This allows the client to always fetch the current active note without worrying about date-based logic.

## Changes
- Removed `month` and `year` fields from the model and added `publishedAt`, `validUntil`, and `isActive` instead
- Added indexes for `publishedAt` and `isActive` in the Prisma schema
- Updated `createUpdateNote` and `updateUpdateNote` APIs to automatically deactivate existing active notes
- Enabled `GET /update-notes/active` to return the currently active note using `"active"` as a special ID
- Refactored note sorting logic to use `publishedAt` instead of `month/year`
- Preserved compatibility with existing APIs like `GET /update-notes/:id`