### PR TITLE
feat: support scheduled publishing and clean up client selects

### DIFF
--- a/prisma/migrations/20250803030007_remove_published_at_default_from_update_note/migration.sql
+++ b/prisma/migrations/20250803030007_remove_published_at_default_from_update_note/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "UpdateNote" ALTER COLUMN "publishedAt" DROP DEFAULT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -176,7 +176,7 @@ model UpdateNote {
   title       String
   description String
   imageUrl    String
-  publishedAt DateTime     @default(now())
+  publishedAt DateTime
   validUntil  DateTime?
   isActive    Boolean      @default(true)
   createdAt   DateTime     @default(now())

--- a/src/config/db.ts
+++ b/src/config/db.ts
@@ -10,9 +10,6 @@ export const gardenItemSelect = {
   imageUrl: true,
   iconUrl: true,
   price: true,
-  createdAt: true,
-  updatedAt: true,
-  // updatedById 제외 (관리자용, 추후 별도 정의 예정)
 };
 
 export const monthlyPlantSelect = {
@@ -22,11 +19,9 @@ export const monthlyPlantSelect = {
   description: true,
   imageUrls: true,
   iconUrl: true,
+  cropImageUrl: true,
   month: true,
   year: true,
-  createdAt: true,
-  updatedAt: true,
-  // updatedById 제외
 };
 
 export const badgeSelect = {
@@ -34,10 +29,6 @@ export const badgeSelect = {
   name: true,
   condition: true,
   imageUrl: true,
-  createdAt: true,
-  updatedAt: true,
-  // updatedById 제외
 };
-
 
 export default prisma;


### PR DESCRIPTION
## Title
feat: support scheduled publishing and clean up client selects

## Purpose
- Previously, the `publishedAt` field in `UpdateNote` was set to default to `now()`, which made it difficult to schedule future releases manually.
- To enable admin-side scheduling, the default value was removed and controller logic was updated to handle future-dated `publishedAt` values during both creation and filtering.
- Additionally, to reduce payload and align with frontend needs, unnecessary timestamps were removed and `cropImageUrl` was added to support the crop system.

## Changes
- **Prisma Schema**
  - Removed `@default(now())` from `UpdateNote.publishedAt`
  - Generated migration: `20250803030007_remove_published_at_default_from_update_note`

- **UpdateNote Controller**
  - Applied `publishedAt`-based scheduling for create/update
  - Filtered notes to return only those already published
  - Added validation for `publishedAt` date format

- **Garden Controller**
  - Returned current update note only if already published (`publishedAt` in the past)
  - Included `gardenItems` in update note history responses for completeness

- **Client Selects Cleanup** (`src/config/db.ts`)
  - Removed `createdAt`, `updatedAt` from `GardenItem`, `MonthlyPlant`, and `Badge` selects
  - Added `cropImageUrl` to `MonthlyPlant` select for monthly crop image support