### PR TITLE
fix: show future updates in admin by removing publishedAt filter

### DIFF
--- a/src/controllers/admin/updateNoteController.ts
+++ b/src/controllers/admin/updateNoteController.ts
@@ -8,7 +8,6 @@ export const getUpdateNotes = async (req: AuthRequest, res: Response) => {
     const now = new Date();
     const updateNotes = await prisma.updateNote.findMany({
       where: {
-        publishedAt: { lte: now },
         OR: [
           { validUntil: null },
           { validUntil: { gte: now } }


### PR DESCRIPTION
## Title
fix: show future updates in admin by removing publishedAt filter

## Purpose
- Previously, update notes scheduled for future publishing were hidden from the Admin Page.
This was due to a `publishedAt <= now` filter in the query.  
- As a result, admins couldn’t preview or manage scheduled content in advance.  
- To fix this, the filter was removed so that all update notes—regardless of publishing time—can be accessed from the admin interface.

## Changes
- Removed `publishedAt <= now` condition from the update notes fetch logic  
- Now all notes, including future-scheduled ones, are shown to admin users  