### PR TITLE
feat: add mainImageUrl to monthlyPlant and support create/update/upload flow

### DIFF
--- a/prisma/migrations/20250804133500_add_main_image_url_to_update_note/migration.sql
+++ b/prisma/migrations/20250804133500_add_main_image_url_to_update_note/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `mainImageUrl` to the `MonthlyPlant` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "MonthlyPlant" ADD COLUMN     "mainImageUrl" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -120,6 +120,7 @@ model MonthlyPlant {
   updatedAt    DateTime    @updatedAt
   updatedById  String?
   id           Int         @id @default(autoincrement())
+  mainImageUrl String
   iconUrl      String
   imageUrls    String[]
   name         String

--- a/src/config/db.ts
+++ b/src/config/db.ts
@@ -17,6 +17,7 @@ export const monthlyPlantSelect = {
   title: true,
   name: true,
   description: true,
+  mainImageUrl: true,
   imageUrls: true,
   iconUrl: true,
   cropImageUrl: true,

--- a/src/controllers/admin/monthlyPlantController.ts
+++ b/src/controllers/admin/monthlyPlantController.ts
@@ -34,10 +34,10 @@ export const getMonthlyPlantById = async (req: AuthRequest, res: Response) => {
 
 export const createMonthlyPlant = async (req: AuthRequest, res: Response) => {
   try {
-    const { title, name, description, imageUrls, iconUrl, cropImageUrl, month, year } = req.body;
+    const { title, name, description, mainImageUrl, imageUrls, iconUrl, cropImageUrl, month, year } = req.body;
     
-    if (!title || !name || !description || !imageUrls || !month || !year) {
-      return res.status(400).json({ message: 'Title, name, description, imageUrls, month, and year are required' });
+    if (!title || !name || !description || !mainImageUrl || !imageUrls || !month || !year) {
+      return res.status(400).json({ message: 'Title, name, description, mainImageUrl, imageUrls, month, and year are required' });
     }
     
     // Validate imageUrls array (should have 4 images for growth stages: SEED, SPROUT, GROWING, MATURE)
@@ -65,6 +65,7 @@ export const createMonthlyPlant = async (req: AuthRequest, res: Response) => {
         title,
         name,
         description,
+        mainImageUrl,
         imageUrls,
         iconUrl,
         cropImageUrl,
@@ -83,7 +84,7 @@ export const createMonthlyPlant = async (req: AuthRequest, res: Response) => {
 
 export const updateMonthlyPlant = async (req: AuthRequest, res: Response) => {
   try {
-    const { title, name, description,iconUrl, cropImageUrl, imageUrls } = req.body;
+    const { title, name, description, mainImageUrl, iconUrl, cropImageUrl, imageUrls } = req.body;
     
     // SuperUser validation is already done in adminAuth middleware
     
@@ -95,6 +96,7 @@ export const updateMonthlyPlant = async (req: AuthRequest, res: Response) => {
     if (title) updateData.title = title;
     if (name) updateData.name = name;
     if (description) updateData.description = description;
+    if (mainImageUrl) updateData.mainImageUrl = mainImageUrl;
     if (iconUrl) updateData.iconUrl = iconUrl;
     if (cropImageUrl) updateData.cropImageUrl = cropImageUrl;
     if (imageUrls) {

--- a/src/controllers/upload/plantUploadController.ts
+++ b/src/controllers/upload/plantUploadController.ts
@@ -80,7 +80,8 @@ export const uploadPlantImage = async (req: AuthRequest, res: Response) => {
         growthImages: growthImageUrls,
         imageUrls: growthImageUrls, // createMonthlyPlant에서 사용할 수 있도록
         iconUrl: iconResult.secure_url, // createMonthlyPlant에서 사용할 수 있도록
-        cropImageUrl: cropResult.secure_url
+        cropImageUrl: cropResult.secure_url,
+        mainImageUrl: mainResult.secure_url,
       } 
     });
   } catch (error) {


### PR DESCRIPTION
## Title
feat: add mainImageUrl to monthlyPlant and support create/update/upload flow

## Purpose
- While testing the admin edit page, the main image was not displaying properly.
- The issue was traced to a missing `mainImageUrl` field in the `MonthlyPlant` model schema.
- This PR adds the missing field and applies it across the create, update, and upload flows, so that the client page can display the image as intended.

## Changes
### Prisma Schema
- Added `mainImageUrl` field to `MonthlyPlant` model
- Applied database migration to reflect schema changes

### DB Config
- Included `mainImageUrl` in `monthlyPlantSelect` for consistent query response

### Admin Controller
- Required `mainImageUrl` in `createMonthlyPlant` input validation
- Supported `mainImageUrl` updates in `updateMonthlyPlant` logic

### Upload Controller
- Returned `mainImageUrl` in `plantUploadController` response to support frontend display