### PR TITLE
feat: support badge awarding with rule-based parsing, controller integration, and admin-side deletion

### DIFF
--- a/src/controllers/auth/userController.ts
+++ b/src/controllers/auth/userController.ts
@@ -2,6 +2,7 @@ import prisma, { badgeSelect, gardenItemSelect, monthlyPlantSelect } from '@/con
 import { AuthRequest } from '@/types/auth';
 import { Response } from 'express';
 import { GitHubCacheService } from '@/services/cacheService';
+import { checkAndAwardBadges } from '@/services/badgeService';
 
 // calculate monthly contributions with Redis cache
 export async function calculateMonthlyContributions(userId: string): Promise<number> {
@@ -303,6 +304,9 @@ export const getUserProfile = async (req: AuthRequest, res: Response) => {
     // Update plants first
     const plantsWithContributions = await autoUpdateAllUserPlants(userId);
 
+    // Check and award badges
+    const newBadges = await checkAndAwardBadges(userId);
+
     // get crops
     const userCrops = await prisma.userCrop.findMany({
       where: { userId },
@@ -346,7 +350,8 @@ export const getUserProfile = async (req: AuthRequest, res: Response) => {
         pots: equippedPots
       },
       plants: plantsWithContributions,
-      crops: userCrops
+      crops: userCrops,
+      newBadges
     });
   } catch (error) {
     console.error('Error fetching user profile:', error);

--- a/src/controllers/item/gardenController.ts
+++ b/src/controllers/item/gardenController.ts
@@ -2,6 +2,7 @@ import prisma, { gardenItemSelect, monthlyPlantSelect } from '@/config/db';
 import { AuthRequest } from '@/types/auth';
 import { Request, Response } from 'express';
 import { UpdateNoteService } from '@/services/updateNoteService';
+import { checkAndAwardBadges } from '@/services/badgeService';
 
 // GARDEN ITEMS
 
@@ -165,9 +166,13 @@ export const sellCrops = async (req: AuthRequest, res: Response) => {
       return { updatedSeed, soldCropsCount: cropIds.length };
     });
 
+    // Check for badges after selling crops
+    const newBadges = await checkAndAwardBadges(req.user!.id);
+
     res.json({
       seeds: result.updatedSeed,
-      soldCropsCount: result.soldCropsCount
+      soldCropsCount: result.soldCropsCount,
+      newBadges
     });
     
   } catch (error: any) {

--- a/src/controllers/item/seedController.ts
+++ b/src/controllers/item/seedController.ts
@@ -1,6 +1,7 @@
 import prisma from '@/config/db';
 import { AuthRequest } from '@/types/auth';
 import { Response } from 'express';
+import { checkAndAwardBadges } from '@/services/badgeService';
 
 // Get user's seed count
 export const getSeedCount = async (req: AuthRequest, res: Response) => {
@@ -36,8 +37,14 @@ export const addSeeds = async (req: AuthRequest, res: Response) => {
         count
       }
     });
+
+    // Check for badges after adding seeds
+    const newBadges = await checkAndAwardBadges(req.user!.id);
     
-    res.json(seed);
+    res.json({
+      ...seed,
+      newBadges
+    });
   } catch (error) {
     res.status(500).json({ message: 'Error adding seeds' });
   }

--- a/src/routes/adminRoutes.ts
+++ b/src/routes/adminRoutes.ts
@@ -1,5 +1,5 @@
 import { createAdminUser, deleteAdminUser, getAdminSession, getAdminStats, getAdminUsers } from '@/controllers/admin/adminController';
-import { createBadge, createGardenItem, deleteGardenItem, getBadges, getGardenItemById, getGardenItems, updateBadge, updateGardenItem } from '@/controllers/admin/itemController';
+import { createBadge, createGardenItem, deleteBadge, deleteGardenItem, getBadges, getGardenItemById, getGardenItems, updateBadge, updateGardenItem } from '@/controllers/admin/itemController';
 import { createMonthlyPlant, deleteMonthlyPlant, getMonthlyPlantById, getMonthlyPlants, updateMonthlyPlant } from '@/controllers/admin/monthlyPlantController';
 import { createUpdateNote, deleteUpdateNote, getUpdateNoteById, getUpdateNotes, updateUpdateNote } from '@/controllers/admin/updateNoteController';
 import { adminAuth, logout } from '@/middlewares/authMiddleware';
@@ -37,6 +37,7 @@ router.delete('/items/:id', deleteGardenItem);
 router.get('/badges', getBadges);
 router.post('/badges', createBadge);
 router.put('/badges/:id', updateBadge);
+router.delete('/badges/:id', deleteBadge);
 
 // UPDATE NOTE MANAGEMENT
 router.get('/update-notes', getUpdateNotes);

--- a/src/services/badgeService.ts
+++ b/src/services/badgeService.ts
@@ -1,0 +1,384 @@
+import prisma from '@/config/db';
+
+type BadgeCache = {
+  badges: Array<{
+    id: number;
+    name: string;
+    condition: string;
+    parsedCondition: BadgeCondition | null;
+  }>;
+  lastUpdated: Date;
+  isStale: boolean;
+};
+
+// simple condition type
+export type BadgeCondition = {
+  type: 'FIRST_LOGIN' | 'FIRST_SEED' | 'FIRST_PLANT' | 'FIRST_HARVEST' | 'CONTRIBUTION_COUNT' | 'HARVEST_COUNT' | 'PLANT_COUNT' | 'JOINED_YEAR' | 'SEED_COUNT';
+  value?: number;
+  period?: 'TOTAL' | 'MONTH';
+};
+
+// cache for badges
+let badgeCache: BadgeCache | null = null;
+const CACHE_TTL = parseInt(process.env.BADGE_CACHE_TTL || '300000'); // default 5 minutes
+
+// cache management functions
+async function loadBadgesToCache(): Promise<BadgeCache> {
+  console.log('Loading badges to cache...');
+  
+  const badges = await prisma.badge.findMany({
+    select: {
+      id: true,
+      name: true,
+      condition: true
+    }
+  });
+
+  const parsedBadges = badges.map(badge => ({
+    ...badge,
+    parsedCondition: parseBadgeCondition(badge.condition)
+  }));
+
+  return {
+    badges: parsedBadges,
+    lastUpdated: new Date(),
+    isStale: false
+  };
+}
+
+function isCacheValid(cache: BadgeCache): boolean {
+  const now = new Date();
+  const timeDiff = now.getTime() - cache.lastUpdated.getTime();
+  return timeDiff < CACHE_TTL && !cache.isStale;
+}
+
+async function getBadgesFromCache(): Promise<BadgeCache['badges']> {
+  if (!badgeCache || !isCacheValid(badgeCache)) {
+    badgeCache = await loadBadgesToCache();
+  }
+  return badgeCache.badges;
+}
+
+// invalidate cache
+export function invalidateBadgeCache(): void {
+  if (badgeCache) {
+    badgeCache.isStale = true;
+  }
+}
+
+// simple keyword condition parsing
+export function parseBadgeCondition(conditionText: string): BadgeCondition | null {
+  const text = conditionText.toLowerCase().trim();
+
+  if (text.includes('start git plants')) {
+    return { type: 'FIRST_LOGIN' };
+  }
+
+  if (text.includes('get first seed')) {
+    return { type: 'FIRST_SEED' };
+  }
+
+  if (text.includes('first plant')) {
+    return { type: 'FIRST_PLANT' };
+  }
+
+  if (text.includes('first harvest')) {
+    return { type: 'FIRST_HARVEST' };
+  }
+
+  // year-based join condition
+  const yearMatch = text.match(/joined in (\d{4})/);
+  if (yearMatch) {
+    const year = parseInt(yearMatch[1]);
+    return { type: 'JOINED_YEAR', value: year };
+  }
+
+  // number-based condition
+  const contributionMatch = text.match(/(\d+)\s*(contribution|commit)/);
+  if (contributionMatch) {
+    const count = parseInt(contributionMatch[1]);
+    const period = text.includes('month') ? 'MONTH' : 'TOTAL';
+    return { type: 'CONTRIBUTION_COUNT', value: count, period };
+  }
+
+  // harvest count condition
+  const harvestMatch = text.match(/(\d+)\s*(harvest|crop)/);
+  if (harvestMatch) {
+    const count = parseInt(harvestMatch[1]);
+    return { type: 'HARVEST_COUNT', value: count };
+  }
+
+  // plant count condition
+  const plantMatch = text.match(/(\d+)\s*plant/);
+  if (plantMatch) {
+    const count = parseInt(plantMatch[1]);
+    return { type: 'PLANT_COUNT', value: count };
+  }
+
+  // seed count condition
+  const seedMatch = text.match(/(\d+)\s*seed/);
+  if (seedMatch) {
+    const count = parseInt(seedMatch[1]);
+    return { type: 'SEED_COUNT', value: count };
+  }
+  
+  return null;
+}
+
+// evaluate badge condition
+export async function evaluateBadgeCondition(
+  condition: BadgeCondition,
+  userId: string
+): Promise<boolean> {
+  try {
+    switch (condition.type) {
+      case 'FIRST_LOGIN':
+        return await evaluateFirstLogin(userId);
+
+      case 'FIRST_SEED':
+        return await evaluateFirstSeed(userId);
+
+      case 'FIRST_PLANT':
+        return await evaluateFirstPlant(userId);
+
+      case 'FIRST_HARVEST':
+        return await evaluateFirstHarvest(userId);
+
+      case 'CONTRIBUTION_COUNT':
+        return await evaluateContributionCount(condition, userId);
+
+      case 'HARVEST_COUNT':
+        return await evaluateHarvestCount(condition, userId);
+
+      case 'PLANT_COUNT':
+        return await evaluatePlantCount(condition, userId);
+
+      case 'JOINED_YEAR':
+        return await evaluateJoinedYear(condition, userId);
+
+      case 'SEED_COUNT':
+        return await evaluateSeedCount(condition, userId);
+
+      default:
+        return false;
+    }
+  } catch (error) {
+    console.error('Error evaluating badge condition:', error);
+    return false;
+  }
+}
+
+// check first login (if already has badge, consider it as first login)
+async function evaluateFirstLogin(userId: string): Promise<boolean> {
+  const userBadges = await prisma.userBadge.count({
+    where: { userId }
+  });
+  return userBadges === 0;
+}
+
+// check first seed
+async function evaluateFirstSeed(userId: string): Promise<boolean> {
+  const seed = await prisma.seed.findUnique({
+    where: { userId }
+  });
+  return seed !== null && seed.count > 0;
+}
+
+// check first plant
+async function evaluateFirstPlant(userId: string): Promise<boolean> {
+  const plantCount = await prisma.userPlant.count({
+    where: { userId }
+  });
+  return plantCount > 0;
+}
+
+// check first harvest
+async function evaluateFirstHarvest(userId: string): Promise<boolean> {
+  const totalHarvests = await prisma.userPlant.aggregate({
+    where: { userId },
+    _sum: { harvestCount: true }
+  });
+  return (totalHarvests._sum.harvestCount || 0) > 0;
+}
+
+// check contributions (growth)
+async function evaluateContributionCount(
+  condition: BadgeCondition,
+  userId: string
+): Promise<boolean> {
+  if (!condition.value) return false;
+
+  const period = condition.period || 'TOTAL';
+
+  if (period === 'TOTAL') {
+    const result = await prisma.gitHubActivity.aggregate({
+      where: { userId },
+      _sum: { count: true }
+    });
+    const totalCount = result._sum.count || 0;
+    return totalCount >= condition.value;
+  }
+
+  if (period === 'MONTH') {
+    const now = new Date();
+    const currentYear = now.getFullYear();
+    const currentMonth = now.getMonth() + 1;
+
+    const monthly = await prisma.gitHubActivity.findUnique({
+      where: {
+        userId_month_year: {
+          userId,
+          month: currentMonth,
+          year: currentYear
+        }
+      },
+      select: { count: true }
+    });
+
+    const monthlyCount = monthly?.count || 0;
+    return monthlyCount >= condition.value;
+  }
+
+  return false;
+}
+
+// check harvest count
+async function evaluateHarvestCount(
+  condition: BadgeCondition,
+  userId: string
+): Promise<boolean> {
+  if (!condition.value) return false;
+
+  const result = await prisma.userPlant.aggregate({
+    where: { userId },
+    _sum: { harvestCount: true }
+  });
+
+  const totalHarvests = result._sum.harvestCount || 0;
+  return totalHarvests >= condition.value;
+}
+
+// check plant count
+async function evaluatePlantCount(
+  condition: BadgeCondition,
+  userId: string
+): Promise<boolean> {
+  if (!condition.value) return false;
+
+  const plantCount = await prisma.userPlant.count({
+    where: { userId }
+  });
+
+  return plantCount >= condition.value;
+}
+
+// check joined year
+async function evaluateJoinedYear(
+  condition: BadgeCondition,
+  userId: string
+): Promise<boolean> {
+  if (!condition.value) return false;
+  
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { createdAt: true }
+    });
+    
+    if (!user) return false;
+    
+    const joinYear = user.createdAt.getFullYear();
+    return joinYear === condition.value;
+  } catch (error) {
+    console.error('Error evaluating joined year condition:', error);
+    return false;
+  }
+}
+
+// evaluate seed count
+async function evaluateSeedCount(
+  condition: BadgeCondition,
+  userId: string
+): Promise<boolean> {
+  if (!condition.value) return false;
+
+  const seed = await prisma.seed.findUnique({
+    where: { userId }
+  });
+
+  const totalSeeds = seed?.count || 0;
+  return totalSeeds >= condition.value;
+}
+
+// check and award badges from cache
+export async function checkAndAwardBadges(userId: string): Promise<string[]> {
+  try {
+    // get badges from cache
+    const cachedBadges = await getBadgesFromCache();
+    const awardedBadges: string[] = [];
+
+    // get existing badges for user (N+1 problem)
+    const existingUserBadges = await prisma.userBadge.findMany({
+      where: { userId },
+      select: { badgeId: true }
+    });
+    
+    const existingBadgeIds = new Set(existingUserBadges.map(ub => ub.badgeId));
+
+    for (const badge of cachedBadges) {
+      // check if already awarded
+      if (existingBadgeIds.has(badge.id)) continue;
+
+      // skip if parsed condition is null
+      if (!badge.parsedCondition) {
+        console.log(`Could not parse condition for badge: ${badge.name} - "${badge.condition}"`);
+        continue;
+      }
+
+      // evaluate condition
+      const shouldAward = await evaluateBadgeCondition(badge.parsedCondition, userId);
+
+      if (shouldAward) {
+        // award badge
+        await prisma.userBadge.create({
+          data: {
+            userId,
+            badgeId: badge.id
+          }
+        });
+
+        awardedBadges.push(badge.name);
+        console.log(`Awarded badge "${badge.name}" to user ${userId}`);
+      }
+    }
+
+    return awardedBadges;
+  } catch (error) {
+    console.error('Error checking and awarding badges:', error);
+    return [];
+  }
+}
+
+// invalidate cache when badge is added/updated/deleted
+export async function addBadgeService(badgeData: { name: string; condition: string; imageUrl: string }): Promise<void> {
+  await prisma.badge.create({ data: badgeData });
+  invalidateBadgeCache();
+}
+
+export async function updateBadgeService(id: number, badgeData: { 
+  name?: string; 
+  condition?: string; 
+  imageUrl?: string;
+  updatedById?: string;
+}): Promise<void> {
+  await prisma.badge.update({ 
+    where: { id }, 
+    data: badgeData 
+  });
+  invalidateBadgeCache();
+}
+
+export async function deleteBadgeService(id: number): Promise<void> {
+  await prisma.badge.delete({ where: { id } });
+  invalidateBadgeCache();
+}


### PR DESCRIPTION
## Title  
feat: support badge awarding with rule-based parsing, controller integration, and admin-side deletion

## Purpose  
- This PR introduces a system that **automatically awards badges** as users interact with the service.  
- To support this, a **condition parsing and evaluation engine** was added, allowing badge rules to be written in simple, human-readable phrases like `"joined in 2024"` or `"10 contributions this month"`.  
- Instead of using a **full-fledged natural language processing (NLP)** engine—which would try to deeply understand human language—this system uses a **simpler rule-based method** based on `keywords` and `regular expressions`.  
  This strikes a balance between being **easy to manage** and **flexible enough** for most admin use cases.  
- **Badge definitions are also cached in memory** to reduce repeated parsing and database lookups, since they rarely change.  
- As a result, these improvements allow for **seamless badge awarding**, **real-time updates**, and a **more admin-friendly authoring experience**.

### Why Keyword-Based Parsing?
- Easier for admins to write logic without learning a strict format  
- New rule types can be added without touching the parser core  
- Faster and more reliable than fragile NLP heuristics  
- Familiar phrases like “first harvest” or “joined in 2025” just work

### Why In-Memory Caching?
- Badge definitions are updated infrequently, so caching makes sense  
- Redis would be overkill for the small scale of this use case  
- TTL-based reloading (`BADGE_CACHE_TTL`) and manual invalidation ensure freshness  
- Keeps evaluation fast and avoids unnecessary DB reads

## Changes  
### Badge Evaluation System
- Implemented `BadgeCondition` parser for rule-based text conditions  
- Supported condition types:  
  `FIRST_LOGIN`, `FIRST_SEED`, `FIRST_PLANT`, `FIRST_HARVEST`, `JOINED_YEAR`, `CONTRIBUTION_COUNT (MONTH | TOTAL)`, `HARVEST_COUNT`, `PLANT_COUNT`, `SEED_COUNT`
- Added evaluation logic for each condition using Prisma queries
- Introduced `checkAndAwardBadges(userId)` to evaluate all cached badge definitions and assign new ones accordingly

### Controller Integration
- `userController.ts`: Trigger badge check on user profile retrieval
- `seedController.ts`: Trigger badge check after seed creation
- `plantController.ts`: Trigger badge check after plant creation and harvesting
- `gardenController.ts`: Trigger badge check after selling crops

### Admin API
- Added `DELETE /admin/badges/:id` route for badge deletion  
- Refactored `createBadge` and `updateBadge` to use `badgeService`  
- Automatically invalidate badge cache on add/update/delete actions

## Optional  
### Badge Condition Guide for Admins  
Admins can create badges through the admin interface by specifying:
- `name`: display name of the badge
- `condition`: human-readable condition string (see examples below)
- `imageUrl`: path to badge icon

When a badge is created, updated, or deleted:
- The system automatically parses the condition string and updates the cache
- Any malformed or unrecognized conditions will be skipped during evaluation
- The badge becomes eligible for evaluation in user-triggered actions (e.g., harvesting, planting)

#### 1. First-time Events
```text
"start git plants" → FIRST_LOGIN  
"first seed" or "get first seed" → FIRST_SEED  
"first plant" → FIRST_PLANT  
"first harvest" → FIRST_HARVEST  
```

#### 2. Join Year Badges
```text
"joined in 2024" → JOINED_YEAR(2024)  
"joined in 2025" → JOINED_YEAR(2025)  
```

#### 3. Contribution-Based Badges
```text
"10 contributions this month" → CONTRIBUTION_COUNT(10, MONTH)  
"50 contributions total" → CONTRIBUTION_COUNT(50, TOTAL)  
```

#### 4. Harvest-Based Badges
```text
"5 harvests" → HARVEST_COUNT(5)  
"50 crops" → HARVEST_COUNT(50)  
```

#### 5. Plant-Based Badges
```text
"10 plants" → PLANT_COUNT(10)  
"100 plants" → PLANT_COUNT(100)  
```

#### Sample SQL Insert
```sql
INSERT INTO Badge (name, condition, imageUrl) VALUES
('Git Plants Pioneer', 'start git plants', 'pioneer.png'),
('First Seed Collector', 'first seed', 'first-seed.png'),
('Plant Master', 'first plant', 'plant-master.png'),
('Harvest King', 'first harvest', 'harvest-king.png'),
('2025 Early Adopter', 'joined in 2025', 'early-adopter.png'),
('Monthly Contributor', '10 contributions this month', 'monthly-contributor.png'),
('Harvest Master', '50 harvests', 'harvest-master.png'),
('Plant Collector', '25 plants', 'plant-collector.png');
```

### Notes
- Conditions must follow one of the supported formats (see examples above)  
- Text is automatically lowercased and trimmed  
- New years or numbers are parsed dynamically (e.g., "joined in 2026", "100 seeds")

Once a condition is parsed, it will be cached and used in evaluation every time the user performs a badge-triggering action.