### PR TITLE
feat: implement DefaultItemService and integrate with GitHub OAuth for automatic awarding of default items

### DIFF
--- a/src/controllers/auth/githubController.ts
+++ b/src/controllers/auth/githubController.ts
@@ -5,6 +5,7 @@ import { fetchUserActivities, setupAutoSync, stopAutoSync } from '@/services/git
 import { AuthRequest } from '@/types/auth';
 import axios from 'axios';
 import { Request, Response } from 'express';
+import { DefaultItemService } from '@/services/defaultItemService';
 
 // start GitHub OAuth login
 export const startGitHubAuth = (req: Request, res: Response) => {
@@ -146,6 +147,10 @@ export const githubCallback = async (req: Request, res: Response) => {
       
       // Auto-create current month's plant
       await autoCreateCurrentMonthPlant(user.id);
+      
+      // Always ensure user has default items (for new users or when defaults change)
+      const defaultItems = await DefaultItemService.awardAllDefaultItems(user.id);
+      console.log(`Ensured default items for user ${user.id}:`, defaultItems);
       
     } catch (error) {
       console.error('Error fetching GitHub activities during login:', error);

--- a/src/services/defaultItemService.ts
+++ b/src/services/defaultItemService.ts
@@ -1,0 +1,131 @@
+import prisma from '@/config/db';
+
+/**
+ * service for awarding default items to users automatically
+ */
+export class DefaultItemService {
+  /**
+   * helper function for awarding items
+   */
+  private static async awardItems(
+    userId: string, 
+    items: Array<{ id: number; name: string }>,
+    category: string
+  ): Promise<string[]> {
+    const awardedItems: string[] = [];
+    
+    for (const item of items) {
+      const existingItem = await prisma.userItem.findFirst({
+        where: { userId, itemId: item.id }
+      });
+
+      if (!existingItem) {
+        await prisma.userItem.create({
+          data: { userId, itemId: item.id }
+        });
+        
+        awardedItems.push(item.name);
+        console.log(`Awarded ${category} "${item.name}" to user ${userId}`);
+      }
+    }
+    
+    return awardedItems;
+  }
+
+  /**
+   * find and award default backgrounds for each mode
+   */
+  static async awardDefaultBackgrounds(userId: string): Promise<{
+    garden: string[];
+    mini: string[];
+  }> {
+    try {
+      console.log(`Awarding default backgrounds to user: ${userId}`);
+      
+      const [gardenBackgrounds, miniBackgrounds] = await Promise.all([
+        prisma.gardenItem.findMany({
+          where: {
+            category: 'background',
+            mode: 'GARDEN',
+            name: { startsWith: 'default_', mode: 'insensitive' }
+          },
+          select: { id: true, name: true }
+        }),
+        prisma.gardenItem.findMany({
+          where: {
+            category: 'background',
+            mode: 'MINI',
+            name: { startsWith: 'default_', mode: 'insensitive' }
+          },
+          select: { id: true, name: true }
+        })
+      ]);
+
+      const [garden, mini] = await Promise.all([
+        this.awardItems(userId, gardenBackgrounds, 'GARDEN background'),
+        this.awardItems(userId, miniBackgrounds, 'MINI background')
+      ]);
+
+      return { garden, mini };
+    } catch (error) {
+      console.error('Error awarding default backgrounds:', error);
+      return { garden: [], mini: [] };
+    }
+  }
+
+  /**
+   * find and award default pots
+   */
+  static async awardDefaultPots(userId: string): Promise<string[]> {
+    try {
+      console.log(`Awarding default pots to user: ${userId}`);
+      
+      const defaultPots = await prisma.gardenItem.findMany({
+        where: {
+          category: 'pot',
+          name: { startsWith: 'default_', mode: 'insensitive' }
+        },
+        select: { id: true, name: true }
+      });
+
+      return await this.awardItems(userId, defaultPots, 'default pot');
+    } catch (error) {
+      console.error('Error awarding default pots:', error);
+      return [];
+    }
+  }
+
+  /**
+   * award all default items (backgrounds and pots)
+   */
+  static async awardAllDefaultItems(userId: string): Promise<{
+    backgrounds: {
+      garden: string[];
+      mini: string[];
+    };
+    pots: string[];
+  }> {
+    try {
+      console.log(`Awarding all default items to user: ${userId}`);
+      
+      const [backgrounds, pots] = await Promise.all([
+        this.awardDefaultBackgrounds(userId),
+        this.awardDefaultPots(userId)
+      ]);
+
+      return {
+        backgrounds,
+        pots
+      };
+    } catch (error) {
+      console.error('Error awarding all default items:', error);
+      return {
+        backgrounds: { garden: [], mini: [] },
+        pots: []
+      };
+    }
+  }
+}
+
+
+


### PR DESCRIPTION
## Title  
feat: implement DefaultItemService and integrate with GitHub OAuth for automatic awarding of default items

## Purpose  
- This PR adds `DefaultItemService` to **automatically award default backgrounds and pots** to new users after GitHub OAuth login.  
- Uses a **naming convention-based lookup** (`default_` prefix) to dynamically find eligible items, avoiding hardcoded IDs or manual setup.  
- Includes **duplicate checks** and logging to ensure reliable, traceable item assignment.

## Changes  
### DefaultItemService
- Added `awardDefaultBackgrounds` for GARDEN/MINI mode default backgrounds  
- Added `awardDefaultPots` for default pots  
- Added `awardAllDefaultItems` for combined background and pot awarding  
- Implemented duplicate check to prevent reassigning owned items  
- Added structured logging for item assignment and errors

### GitHub OAuth Integration
- Imported `DefaultItemService` in `githubController`  
- Called `awardAllDefaultItems` after first-time GitHub login  
- Added logging to confirm awarded items during OAuth flow

## Optional  
### Default Item Naming Convention for Admins  
Default items are identified by names starting with `default_`.  
For example:  
- `default_garden_background`  
- `default_mini_background`  
- `default_pot`  
Any new item following this naming rule will be automatically assigned to new users.