### PR TITLE
feat: add imageUrl to badge awarding and simplify default item flow

### DIFF
--- a/src/controllers/auth/githubController.ts
+++ b/src/controllers/auth/githubController.ts
@@ -149,8 +149,7 @@ export const githubCallback = async (req: Request, res: Response) => {
       await autoCreateCurrentMonthPlant(user.id);
       
       // Always ensure user has default items (for new users or when defaults change)
-      const defaultItems = await DefaultItemService.awardAllDefaultItems(user.id);
-      console.log(`Ensured default items for user ${user.id}:`, defaultItems);
+      await DefaultItemService.awardAllDefaultItems(user.id);
       
     } catch (error) {
       console.error('Error fetching GitHub activities during login:', error);

--- a/src/services/badgeService.ts
+++ b/src/services/badgeService.ts
@@ -311,11 +311,11 @@ async function evaluateSeedCount(
 }
 
 // check and award badges from cache
-export async function checkAndAwardBadges(userId: string): Promise<string[]> {
+export async function checkAndAwardBadges(userId: string): Promise<Array<{name: string, imageUrl: string}>> {
   try {
     // get badges from cache
     const cachedBadges = await getBadgesFromCache();
-    const awardedBadges: string[] = [];
+    const awardedBadges: Array<{name: string, imageUrl: string}> = [];
 
     // get existing badges for user (N+1 problem)
     const existingUserBadges = await prisma.userBadge.findMany({
@@ -347,7 +347,19 @@ export async function checkAndAwardBadges(userId: string): Promise<string[]> {
           }
         });
 
-        awardedBadges.push(badge.name);
+        // Get badge details including imageUrl
+        const badgeDetails = await prisma.badge.findUnique({
+          where: { id: badge.id },
+          select: { name: true, imageUrl: true }
+        });
+
+        if (badgeDetails) {
+          awardedBadges.push({
+            name: badgeDetails.name,
+            imageUrl: badgeDetails.imageUrl
+          });
+        }
+
         console.log(`Awarded badge "${badge.name}" to user ${userId}`);
       }
     }

--- a/src/services/defaultItemService.ts
+++ b/src/services/defaultItemService.ts
@@ -25,8 +25,12 @@ export class DefaultItemService {
         });
         
         awardedItems.push(item.name);
-        console.log(`Awarded ${category} "${item.name}" to user ${userId}`);
       }
+    }
+    
+    // Only log if items were actually awarded
+    if (awardedItems.length > 0) {
+      console.log(`Awarded ${category}s to user ${userId}: ${awardedItems.join(', ')}`);
     }
     
     return awardedItems;
@@ -40,8 +44,6 @@ export class DefaultItemService {
     mini: string[];
   }> {
     try {
-      console.log(`Awarding default backgrounds to user: ${userId}`);
-      
       const [gardenBackgrounds, miniBackgrounds] = await Promise.all([
         prisma.gardenItem.findMany({
           where: {
@@ -78,8 +80,6 @@ export class DefaultItemService {
    */
   static async awardDefaultPots(userId: string): Promise<string[]> {
     try {
-      console.log(`Awarding default pots to user: ${userId}`);
-      
       const defaultPots = await prisma.gardenItem.findMany({
         where: {
           category: 'pot',
@@ -106,8 +106,6 @@ export class DefaultItemService {
     pots: string[];
   }> {
     try {
-      console.log(`Awarding all default items to user: ${userId}`);
-      
       const [backgrounds, pots] = await Promise.all([
         this.awardDefaultBackgrounds(userId),
         this.awardDefaultPots(userId)


### PR DESCRIPTION
## Title  
feat: add imageUrl to badge awarding and simplify default item flow

## Purpose  
- While working on the notification modal for newly awarded badges in frontend pages, existing logic only returned the badge name.  
- To display the badge image in the modal, the API response needed to include an imageUrl field.  
- For better UX, the response was updated to return both the badge name and its image URL.  
- Additionally, unnecessary logs in `DefaultItemService` and `githubController` were removed, and the default item awarding flow was simplified for cleaner code.

Example response after changes:
```json
[
  {
    "name": "Contributor",
    "imageUrl": "https://example.com/badges/contributor.png"
  },
  {
    "name": "Early Bird",
    "imageUrl": "https://example.com/badges/earlybird.png"
  }
]
```

## Changes
- **Badge Service**
  - Changed `checkAndAwardBadges` return type from `string[]` to `Array<{ name: string, imageUrl: string }>`
  - Included image URL in the returned data for richer badge display in the frontend
  - Enables the frontend notification modal to show both badge name and image when awarded

- **GitHub OAuth**
  - Removed unnecessary `console.log` statements after default item awarding
  - Directly invoked `DefaultItemService.awardAllDefaultItems(user.id)` without storing in a variable

- **Default Item Service**
  - Removed detailed per-item logs; now logs only a concise summary when items are actually awarded
  - Removed redundant start-of-method logs
  - Made log messages more concise and useful