### PR TITLE
fix: install dev dependencies for build then prune after compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,14 @@ WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
 
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --frozen-lockfile
 
 COPY . .
 
 RUN pnpm run build
+
+# Clean up dev dependencies after build
+RUN pnpm prune --prod
 
 EXPOSE $PORT
 


### PR DESCRIPTION
## Title
fix: install dev dependencies during build and prune after compilation

## Purpose
- The Docker build previously failed because `tsc` (TypeScript) was missing when using the `--prod` flag, which excluded devDependencies.
- To address this, all dependencies are now installed during the build so TypeScript is available for compilation, and then `pnpm prune --prod` is used to remove unnecessary devDependencies.
- This ensures the build completes successfully while keeping the final image optimized with only production dependencies.

## Changes
- Updated Dockerfile to install all dependencies during build
- Replaced `pnpm install --prod --frozen-lockfile` with `pnpm install --frozen-lockfile`
- Added `pnpm prune --prod` step after compilation
- Ensured the final image contains only production dependencies