### PR TITLE
fix: move tsconfig-paths to dependencies for production runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "generating plant visuals based on GitHub activity, designed for use in profile READMEs",
   "main": "dist/server.ts",
   "scripts": {
-    "start": "node dist/server.js",
+    "start": "node -r tsconfig-paths/register dist/server.js",
     "dev": "ts-node-dev -r tsconfig-paths/register --respawn src/server.ts",
     "build": "tsc"
   },
@@ -24,7 +24,8 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.1",
     "prisma": "^6.8.2",
-    "redis": "^5.7.0"
+    "redis": "^5.7.0",
+    "tsconfig-paths": "^4.2.0"
   },
   "devDependencies": {
     "@types/cookie-parser": "^1.4.8",
@@ -33,7 +34,6 @@
     "@types/jsonwebtoken": "^9.0.9",
     "@types/node": "^20.11.24",
     "ts-node-dev": "^2.0.0",
-    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.3.3"
   }
 }


### PR DESCRIPTION
## Title  
fix: move tsconfig-paths to dependencies for production runtime

## Purpose  
- In the production environment, TypeScript path mapping (`@/*`) was not resolved after compilation, causing runtime errors.  
- The issue occurred because `tsconfig-paths` was only listed in `devDependencies`, making it unavailable during production runtime.  
- To resolve this, the `start` script was updated to preload `tsconfig-paths/register`, and `tsconfig-paths` was moved to `dependencies`.  
- This ensures consistent path resolution across both development and production environments.

## Changes  
### Docker/Runtime Fixes
- Updated `start` script to use `-r tsconfig-paths/register` so that path aliases are resolved at runtime
- Moved `tsconfig-paths` from `devDependencies` to `dependencies` for production availability

### TypeScript Path Mapping Explanation
1. **Why it worked in development**
   - `dev`: `ts-node-dev -r tsconfig-paths/register --respawn src/server.ts`
   - `ts-node-dev` executes TypeScript directly, while `tsconfig-paths/register` resolves `@/*` aliases on the fly using `tsconfig.json`.

2. **Why it failed in production**
   - `start`: `node dist/server.js` (original script)
   - During compilation, `import { getActivityById } from '@/controllers/auth/githubController'` became `require('@/controllers/auth/githubController')`.
   - Node.js does not understand `@/` and attempts to resolve it as:
     1. `node_modules/@/...` ❌  
     2. Absolute path ❌  
     3. Relative path ❌  
     → Result: `MODULE_NOT_FOUND` error 💥  

3. **Chosen solution**
   - `"start": "node -r tsconfig-paths/register dist/server.js"`
   - At runtime, `tsconfig-paths` reads the `paths` config from `tsconfig.json` and correctly maps `@/controllers/auth/githubController` → `src/controllers/auth/githubController`.

## Outcome
- Fix the `MODULE_NOT_FOUND` runtime error in production by enabling proper path alias resolution.
- Confirm a core limitation of TypeScript: it handles type checking and compilation, but not runtime module resolution without additional tools.