### PR TITLE
fix: sync pnpm lockfile, and align Node.js versions in CI/CD with Dockerfile

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '22'
         cache: 'pnpm'
     
     - name: Install pnpm

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       redis:
         specifier: ^5.7.0
         version: 5.8.2
+      tsconfig-paths:
+        specifier: ^4.2.0
+        version: 4.2.0
     devDependencies:
       '@types/cookie-parser':
         specifier: ^1.4.8
@@ -69,9 +72,6 @@ importers:
       ts-node-dev:
         specifier: ^2.0.0
         version: 2.0.0(@types/node@20.19.11)(typescript@5.9.2)
-      tsconfig-paths:
-        specifier: ^4.2.0
-        version: 4.2.0
       typescript:
         specifier: ^5.3.3
         version: 5.9.2


### PR DESCRIPTION
## Title  
fix: sync pnpm lockfile, and align Node.js versions in CI/CD with Dockerfile

## Purpose  
- `pnpm-lock.yaml` was not in sync with `package.json`, which caused lockfile mismatch errors during Docker builds.  
- CI/CD was running on Node.js 18 while the Dockerfile used Node.js 22, leading to inconsistencies across environments.  
- To ensure stable and consistent deployments, the lockfile was synced and Node.js versions were aligned across Docker and CI/CD.  

## Changes  
- Updated `pnpm-lock.yaml` to match `package.json`  
- Upgraded CI/CD workflow to use Node.js 22, consistent with Dockerfile  