### PR TITLE
fix: update build/start scripts with tsc-alias and resolve Prisma build warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
 
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile && pnpm approve-builds
 
 COPY . .
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "generating plant visuals based on GitHub activity, designed for use in profile READMEs",
   "main": "dist/server.ts",
   "scripts": {
-    "start": "node -r tsconfig-paths/register dist/server.js",
+    "start": "node dist/server.js",
     "dev": "ts-node-dev -r tsconfig-paths/register --respawn src/server.ts",
-    "build": "tsc"
+    "build": "tsc && tsc-alias"
   },
   "author": "reizvoll",
   "license": "MIT",


### PR DESCRIPTION
## Title  
fix: update build/start scripts with tsc-alias and resolve Prisma build warnings

## Purpose  
- In production, TypeScript path mapping (`@/*`) caused runtime errors when relying on `tsconfig-paths`.  
- The build process was updated to use `tsc-alias`, which transforms path aliases at build time, removing the need for runtime dependencies.  
- Additionally, Prisma build warnings during Docker builds were resolved by adding `pnpm approve-builds`.

## Changes  
### package.json  
- **start script**: removed `tsconfig-paths/register` since path aliases are now transformed during build  
- **build script**: updated to `tsc && tsc-alias` for compiling TypeScript and applying path alias transformation  

### Dockerfile  
- Added `pnpm approve-builds` to suppress and resolve Prisma build-time warnings  

## Outcome  
- Eliminates runtime dependency on `tsconfig-paths` by applying path alias resolution at build time  
- Prevents `MODULE_NOT_FOUND` errors in production and simplifies runtime execution  
- Resolves Prisma build warnings for cleaner and more stable Docker builds  