### PR TITLE
feat: split GitHub OAuth flow and add Render deployment config

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -13,9 +13,46 @@ services:
         value: production
       - key: PORT
         value: 10000
+      - key: REDIS_URL
+        fromService:
+          type: redis
+          name: git-plants-redis
+          property: connectionString
+      # All Environment Variables (set in Render Dashboard)
+      - key: GITHUB_CLIENT_ID
+        sync: false
+      - key: GITHUB_CLIENT_SECRET
+        sync: false
+      - key: GITHUB_CALLBACK_URL
+        sync: false
+      - key: JWT_SECRET
+        sync: false
+      - key: JWT_REFRESH_SECRET
+        sync: false
+      - key: CLIENT_URL
+        sync: false
+      - key: ADMIN_URL
+        sync: false
+      - key: REDIS_RECONNECT_DELAY_MS
+        sync: false
+      - key: CACHE_TTL_SECONDS
+        sync: false
+      - key: CACHE_PREFIX
+        sync: false
+      - key: GITHUB_SYNC_INTERVAL_MS
+        sync: false
+      - key: IS_REDIS_PRODUCTION
+        sync: false
+      - key: BADGE_CACHE_TTL
+        sync: false
+
+  - type: redis
+    name: git-plants-redis
+    plan: free
+    maxmemoryPolicy: allkeys-lru
 
 databases:
   - name: git-plants-db
     databaseName: git_plants
     user: git_plants_user
-    plan: starter
+    plan: free

--- a/src/controllers/auth/githubController.ts
+++ b/src/controllers/auth/githubController.ts
@@ -7,9 +7,15 @@ import axios from 'axios';
 import { Request, Response } from 'express';
 import { DefaultItemService } from '@/services/defaultItemService';
 
-// start GitHub OAuth login
+// start GitHub OAuth login for client
 export const startGitHubAuth = (req: Request, res: Response) => {
-  const githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${authConfig.github.clientId}&redirect_uri=${authConfig.github.callbackURL}&scope=${authConfig.github.scope}`;
+  const githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${authConfig.github.clientId}&redirect_uri=${authConfig.github.callbackURL}&scope=${authConfig.github.scope}&state=client`;
+  res.redirect(githubAuthUrl);
+};
+
+// start GitHub OAuth login for admin
+export const startGitHubAuthAdmin = (req: Request, res: Response) => {
+  const githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${authConfig.github.clientId}&redirect_uri=${authConfig.github.callbackURL}&scope=${authConfig.github.scope}&state=admin`;
   res.redirect(githubAuthUrl);
 };
 
@@ -68,7 +74,7 @@ async function autoCreateCurrentMonthPlant(userId: string) {
 
 // GitHub OAuth callback
 export const githubCallback = async (req: Request, res: Response) => {
-  const { code } = req.query;
+  const { code, state } = req.query;
   
   try {
     // get GitHub access token
@@ -155,11 +161,13 @@ export const githubCallback = async (req: Request, res: Response) => {
       console.error('Error fetching GitHub activities during login:', error);
     }
 
-    // redirect to frontend
-    res.redirect(`${process.env.CLIENT_URL}/auth/callback`);
+    // redirect to frontend based on state parameter
+    const redirectUrl = state === 'admin' ? process.env.ADMIN_URL : process.env.CLIENT_URL;
+    res.redirect(`${redirectUrl}/auth/callback`);
   } catch (error) {
     console.error('GitHub OAuth error:', error);
-    res.redirect(`${process.env.CLIENT_URL}/auth/error`);
+    const redirectUrl = state === 'admin' ? process.env.ADMIN_URL : process.env.CLIENT_URL;
+    res.redirect(`${redirectUrl}/auth/error`);
   }
 }; 
 

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -1,4 +1,4 @@
-import { githubCallback, startGitHubAuth } from '@/controllers/auth/githubController';
+import { githubCallback, startGitHubAuth, startGitHubAuthAdmin } from '@/controllers/auth/githubController';
 import { getSession, refreshToken } from '@/controllers/auth/sessionController';
 import { clientAuth, logout } from '@/middlewares/authMiddleware';
 import { loginLimiter } from '@/middlewares/rateLimiter';
@@ -6,8 +6,11 @@ import express from 'express';
 
 const router = express.Router();
 
-// start GitHub OAuth login
+// start GitHub OAuth login for client
 router.get('/github', loginLimiter, startGitHubAuth);
+
+// start GitHub OAuth login for admin
+router.get('/github/admin', loginLimiter, startGitHubAuthAdmin);
 
 // GitHub OAuth callback
 router.get('/callback/github', githubCallback);


### PR DESCRIPTION
## Title
feat: split GitHub OAuth flow and add Render deployment config

## Purpose
- GitHub OAuth was limited to a single endpoint, preventing admin-specific authentication.
This was resolved by splitting the flow into client and admin routes with state-based redirection.
- For production stability, a comprehensive Render deployment setup was introduced, including Redis and PostgreSQL services, centralized environment variable management, and production-ready Redis configuration.

## Changes
### GitHub OAuth
- Added separate routes: `/api/auth/github` (client) and `/api/auth/github/admin` (admin)
- Implemented state-based redirect logic for CLIENT_URL vs ADMIN_URL
- Updated error handling to redirect to the correct frontend on failure
- Added `ADMIN_URL` to `.env.example` for local admin development

### Deployment Configuration
- Added `render.yaml` with Redis and PostgreSQL services (free tier)
- Configured automatic injection for `DATABASE_URL` and `REDIS_URL`
- Centralized environment variables for OAuth, JWT, and cache settings
- Introduced `IS_REDIS_PRODUCTION` flag to enable production Redis usage
- All environment variables managed via Render Dashboard (sync: false)