### PR TITLE
chore: revert Render blueprint service auto-creation and switch to manual setup

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -8,18 +8,13 @@ services:
     region: oregon
     buildCommand: npm run build
     startCommand: npm start
-    dependsOn:
-      - git-plants-redis
     envVars:
       - key: NODE_ENV
         value: production
       - key: PORT
         value: 10000
       - key: REDIS_URL
-        fromService:
-          type: keyvalue
-          name: git-plants-redis
-          property: connectionString
+        sync: false
       # All Environment Variables (set in Render Dashboard)
       - key: GITHUB_CLIENT_ID
         sync: false
@@ -48,14 +43,3 @@ services:
       - key: BADGE_CACHE_TTL
         sync: false
 
-  - type: keyvalue
-    name: git-plants-redis
-    plan: free
-    maxmemoryPolicy: allkeys-lru
-    ipAllowList: []
-
-databases:
-  - name: git-plants-db
-    databaseName: git_plants
-    user: git_plants_user
-    plan: free


### PR DESCRIPTION
## Title
chore: revert Render blueprint service auto-creation and switch to manual setup

## Purpose
- Render blueprint was used to automatically provision Redis and Postgres services, but the auto-creation and environment variable injection did not work reliably.
- To stabilize deployment, the managed service definitions were removed from the blueprint and services will be created manually through the Render Dashboard instead.
- This change simplifies configuration and ensures environment variables like `REDIS_URL` and `DATABASE_URL` are injected correctly.

## Changes
- **render.yaml**
  - Removed Redis (Key-Value Store) service definition
  - Removed Postgres database service definition
  - Dropped related environment variable references for auto-injection

- **Deployment Process**
  - Updated flow to rely on manually created Redis/Postgres services in Render Dashboard
  - Environment variables now configured manually for consistency