### PR TITLE
fix: resolve session 401 error by updating auth middlewares

### DIFF
--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -165,7 +165,10 @@ export const clientAuth = async (req: Request, res: Response, next: NextFunction
                 maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
             });
 
-            return res.status(200).json({ message: 'Token refreshed' });
+            // Set user info and continue to next middleware
+            req.user = { id: storedToken.user.id, username: storedToken.user.username, image: storedToken.user.image || undefined };
+            req.isAdmin = storedToken.isAdmin;
+            next();
         }
     } catch (error) {
         console.error('Auth error:', error);
@@ -235,7 +238,11 @@ export const adminAuth = async (req: Request, res: Response, next: NextFunction)
                 maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
             });
 
-            return res.status(200).json({ message: 'Token refreshed' });
+            // Set user info and continue to next middleware (superUser already validated above)
+            req.user = { id: storedToken.user.id, username: storedToken.user.username, image: storedToken.user.image || undefined };
+            req.isAdmin = true;
+            req.superUser = superUser;
+            next();
         }
     } catch (error) {
         console.error('Auth error:', error);


### PR DESCRIPTION
## Title  
fix: resolve session 401 error by updating auth middlewares

## Purpose  
- When the session API was called after token refresh, the middleware returned only 
`{ message: 'Token refreshed' }` instead of passing user information.
- This caused the frontend to consistently receive 401 errors and fail to retrieve session data.  
- The middleware was updated to set `req.user` and continue execution with `next()`, ensuring proper session information is returned.

## Changes
### Middleware (clientAuth/adminAuth)
- Removed early return with `res.status(200).json`
- Added logic to attach `req.user` and `req.isAdmin`(in client) / `req.superUser` (in admin)
- Allowed flow to continue via `next()`

### Additional Fixes  
- Fixed TypeScript typing issue: `string | null` → `string | undefined`  
- Removed duplicate `superUser` declaration

## Result  
- Before: Token refresh returned `{ message: 'Token refreshed' }` → frontend received no session info → 401 error.  
- After: Token refresh calls `next()` with user data set → session API returns valid user information without errors.  