### PR TITLE
fix: revert cookie settings for cross-domain compatibility (401 issue)

### DIFF
--- a/src/config/auth.ts
+++ b/src/config/auth.ts
@@ -25,9 +25,6 @@ export const authConfig = {
         sameSite: 'lax' as 'strict' | 'lax' | 'none',
         path: '/',
         maxAge: 7 * 24 * 60 * 60 * 1000,
-        ...(process.env.NODE_ENV === 'production' && process.env.COOKIE_DOMAIN && { 
-          domain: process.env.COOKIE_DOMAIN 
-        })
       }
     },
     client: {
@@ -39,9 +36,6 @@ export const authConfig = {
         sameSite: 'lax' as 'strict' | 'lax' | 'none',
         path: '/',
         maxAge: 7 * 24 * 60 * 60 * 1000,
-        ...(process.env.NODE_ENV === 'production' && process.env.COOKIE_DOMAIN && { 
-          domain: process.env.COOKIE_DOMAIN 
-        })
       }
     }
   }

--- a/src/config/auth.ts
+++ b/src/config/auth.ts
@@ -22,7 +22,7 @@ export const authConfig = {
       options: {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
-        sameSite: (process.env.NODE_ENV === 'production' ? 'none' : 'lax') as 'strict' | 'lax' | 'none',
+        sameSite: 'lax' as 'strict' | 'lax' | 'none',
         path: '/',
         maxAge: 7 * 24 * 60 * 60 * 1000,
         ...(process.env.NODE_ENV === 'production' && process.env.COOKIE_DOMAIN && { 
@@ -36,7 +36,7 @@ export const authConfig = {
       options: {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
-        sameSite: (process.env.NODE_ENV === 'production' ? 'none' : 'lax') as 'strict' | 'lax' | 'none',
+        sameSite: 'lax' as 'strict' | 'lax' | 'none',
         path: '/',
         maxAge: 7 * 24 * 60 * 60 * 1000,
         ...(process.env.NODE_ENV === 'production' && process.env.COOKIE_DOMAIN && { 


### PR DESCRIPTION
## Title  
fix: revert cookie settings for cross-domain compatibility (401 issue)

## Purpose  
- Recent cookie configuration caused 401 errors in cross-domain authentication flows.  
- To resolve this, cookie settings were reverted to more compatible defaults by removing domain restrictions and relaxing sameSite rules.

## Changes  
- Updated cookie option to use `sameSite: 'lax'` for cross-domain requests.  
- Removed `COOKIE_DOMAIN` configuration from auth settings to avoid unnecessary domain binding.