### PR TITLE
feat: add public API for generating README profile images

### DIFF
--- a/src/routes/publicRoutes.ts
+++ b/src/routes/publicRoutes.ts
@@ -1,4 +1,5 @@
 import { getCurrentUpdateNote, getMonthlyPlants, getGardenItems } from '@/controllers/item/gardenController';
+import { getPublicUserProfile } from '@/controllers/auth/userController';
 import express from 'express';
 
 const router = express.Router();
@@ -11,5 +12,8 @@ router.get('/current-update', getCurrentUpdateNote);
 
 // 모든 garden 아이템 조회 (상점페이지용)
 router.get('/items', getGardenItems);
+
+// 공개 유저 프로필 (리드미용)
+router.get('/profile/:username', getPublicUserProfile);
 
 export default router; 


### PR DESCRIPTION
## Title
feat: add public API for generating README profile images

## Purpose
- A public endpoint was needed to generate user profile images that can be embedded in README without requiring authentication.
- Based on `username`, the API provides equipped items (background, pot) and plant data to be used for image generation.
- Unlike the existing token-based profile API, this public version is simplified and designed for external accessibility.

## Changes
### Public Image API
- Implemented `getPublicUserProfile` controller to fetch user data by `username`
- Returned equipped items (background, pot) and plant details in a format usable for image rendering
- Included translation fields for multilingual README usage

### Routing
- Added `GET /profile/:username` under `publicRoutes`
- Connected the new route to `getPublicUserProfile` controller for token-free access